### PR TITLE
Add GitHub star repo button to website

### DIFF
--- a/client/appWeb/appWeb/src/jsMain/resources/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/index.html
@@ -6,17 +6,17 @@
     <meta name="description" content="Find the perfect GIF for your coding break." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Facebook -->
-    <meta property="og:url" content="https://thecodinglove.gchristov.com" />
+    <meta property="og:url" content="https://thecodinglove.crowdstandout.com" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="The Coding Love GIFs" />
     <meta property="og:description" content="Find the perfect GIF for your coding break." />
-    <meta property="og:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta property="og:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Twitter -->
-    <meta name=”twitter:site” content=”https://thecodinglove.gchristov.com” /> 
+    <meta name=”twitter:site” content=”https://thecodinglove.crowdstandout.com” />
     <meta name="twitter:card" content="A bit of developer humor for your break" />
     <meta name="twitter:title" content="The Coding Love GIFs" />
     <meta name="twitter:description" content="Find the perfect GIF for your coding break." />
-    <meta name="twitter:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta name="twitter:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Slack -->
     <meta name="slack-app-id" content="AFNEWBNFN">
     <!-- Fav + shortcut icons -->
@@ -56,6 +56,9 @@
         <a href="/" aria-current="page" class="w-nav-brand w--current"><img src="/static/images/logo.png" loading="lazy" alt="" class="navbar__logo" style="height: 34px; width: auto;" /></a>
         <div>
           <nav role="navigation" class="nav-menu w-nav-menu">
+            <span class="nav-link w-nav-link" style="margin-bottom: -5px;">
+              <a class="github-button" href="https://github.com/gchristov/thecodinglove-kotlinjs" data-size="large" data-show-count="true" aria-label="Star gchristov/thecodinglove-kotlinjs on GitHub">Star</a>
+            </span>
             <a href="support" class="nav-link w-nav-link">Support</a>
             <a href="terms" class="nav-link w-nav-link">Terms of Service</a>
             <a href="privacy-policy" class="nav-link w-nav-link">Privacy Policy</a>
@@ -123,5 +126,6 @@
       </div>
     </div>
     <script src="/static/js/jquery-3.5.1.min.js" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>
 </html>

--- a/client/appWeb/appWeb/src/jsMain/resources/privacy-policy/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/privacy-policy/index.html
@@ -6,17 +6,17 @@
     <meta name="description" content="Find the perfect GIF for your coding break." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Facebook -->
-    <meta property="og:url" content="https://thecodinglove.gchristov.com/support" />
+    <meta property="og:url" content="https://thecodinglove.crowdstandout.com/support" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Support" />
     <meta property="og:description" content="Find the perfect GIF for your coding break." />
-    <meta property="og:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta property="og:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Twitter -->
-    <meta name=”twitter:site” content=”https://thecodinglove.gchristov.com/support” /> 
+    <meta name=”twitter:site” content=”https://thecodinglove.crowdstandout.com/support” />
     <meta name="twitter:card" content="A bit of developer humor for your break" />
     <meta name="twitter:title" content="Support" />
     <meta name="twitter:description" content="Find the perfect GIF for your coding break." />
-    <meta name="twitter:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta name="twitter:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Slack -->
     <meta name="slack-app-id" content="AFNEWBNFN">
     <!-- Fav + shortcut icons -->
@@ -56,6 +56,9 @@
         <a href="/" aria-current="page" class="w-nav-brand w--current"><img src="/static/images/logo.png" loading="lazy" alt="" class="navbar__logo" style="height: 34px; width: auto;" /></a>
         <div>
           <nav role="navigation" class="nav-menu w-nav-menu">
+            <span class="nav-link w-nav-link" style="margin-bottom: -5px;">
+              <a class="github-button" href="https://github.com/gchristov/thecodinglove-kotlinjs" data-size="large" data-show-count="true" aria-label="Star gchristov/thecodinglove-kotlinjs on GitHub">Star</a>
+            </span>
             <a href="/support" class="nav-link w-nav-link">Support</a>
             <a href="/terms" class="nav-link w-nav-link">Terms of Service</a>
             <a href="/privacy-policy" class="nav-link w-nav-link">Privacy Policy</a>
@@ -172,5 +175,6 @@
     </div>
     <script src="/static/js/jquery-3.5.1.min.js" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <script src="/static/js/contact.js" type="text/javascript" crossorigin="anonymous"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>
 </html>

--- a/client/appWeb/appWeb/src/jsMain/resources/privacy-policy/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/privacy-policy/index.html
@@ -8,13 +8,13 @@
     <!-- Facebook -->
     <meta property="og:url" content="https://thecodinglove.crowdstandout.com/support" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Support" />
+    <meta property="og:title" content="Privacy Policy" />
     <meta property="og:description" content="Find the perfect GIF for your coding break." />
     <meta property="og:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Twitter -->
     <meta name=”twitter:site” content=”https://thecodinglove.crowdstandout.com/support” />
     <meta name="twitter:card" content="A bit of developer humor for your break" />
-    <meta name="twitter:title" content="Support" />
+    <meta name="twitter:title" content="Privacy Policy" />
     <meta name="twitter:description" content="Find the perfect GIF for your coding break." />
     <meta name="twitter:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Slack -->

--- a/client/appWeb/appWeb/src/jsMain/resources/support/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/support/index.html
@@ -6,17 +6,17 @@
     <meta name="description" content="Find the perfect GIF for your coding break." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Facebook -->
-    <meta property="og:url" content="https://thecodinglove.gchristov.com/support" />
+    <meta property="og:url" content="https://thecodinglove.crowdstandout.com/support" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Support" />
     <meta property="og:description" content="Find the perfect GIF for your coding break." />
-    <meta property="og:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta property="og:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Twitter -->
-    <meta name=”twitter:site” content=”https://thecodinglove.gchristov.com/support” /> 
+    <meta name=”twitter:site” content=”https://thecodinglove.crowdstandout.com/support” />
     <meta name="twitter:card" content="A bit of developer humor for your break" />
     <meta name="twitter:title" content="Support" />
     <meta name="twitter:description" content="Find the perfect GIF for your coding break." />
-    <meta name="twitter:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta name="twitter:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Slack -->
     <meta name="slack-app-id" content="AFNEWBNFN">
     <!-- Fav + shortcut icons -->
@@ -56,6 +56,9 @@
         <a href="/" aria-current="page" class="w-nav-brand w--current"><img src="/static/images/logo.png" loading="lazy" alt="" class="navbar__logo" style="height: 34px; width: auto;" /></a>
         <div>
           <nav role="navigation" class="nav-menu w-nav-menu">
+            <span class="nav-link w-nav-link" style="margin-bottom: -5px;">
+              <a class="github-button" href="https://github.com/gchristov/thecodinglove-kotlinjs" data-size="large" data-show-count="true" aria-label="Star gchristov/thecodinglove-kotlinjs on GitHub">Star</a>
+            </span>
             <a href="/support" class="nav-link w-nav-link">Support</a>
             <a href="/terms" class="nav-link w-nav-link">Terms of Service</a>
             <a href="/privacy-policy" class="nav-link w-nav-link">Privacy Policy</a>
@@ -109,5 +112,6 @@
     </div>
     <script src="/static/js/jquery-3.5.1.min.js" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <script src="/static/js/contact.js" type="text/javascript" crossorigin="anonymous"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>
 </html>

--- a/client/appWeb/appWeb/src/jsMain/resources/terms/index.html
+++ b/client/appWeb/appWeb/src/jsMain/resources/terms/index.html
@@ -6,17 +6,17 @@
     <meta name="description" content="Find the perfect GIF for your coding break." />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Facebook -->
-    <meta property="og:url" content="https://thecodinglove.gchristov.com/support" />
+    <meta property="og:url" content="https://thecodinglove.crowdstandout.com/support" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Terms of Service" />
     <meta property="og:description" content="Find the perfect GIF for your coding break." />
-    <meta property="og:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta property="og:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Twitter -->
-    <meta name=”twitter:site” content=”https://thecodinglove.gchristov.com/support” /> 
+    <meta name=”twitter:site” content=”https://thecodinglove.crowdstandout.com/support” />
     <meta name="twitter:card" content="A bit of developer humor for your break" />
     <meta name="twitter:title" content="Terms of Service" />
     <meta name="twitter:description" content="Find the perfect GIF for your coding break." />
-    <meta name="twitter:image" content="https://thecodinglove.gchristov.com/static/images/icon.jpg" />
+    <meta name="twitter:image" content="https://thecodinglove.crowdstandout.com/static/images/icon.jpg" />
     <!-- Slack -->
     <meta name="slack-app-id" content="AFNEWBNFN">
     <!-- Fav + shortcut icons -->
@@ -56,6 +56,9 @@
         <a href="/" aria-current="page" class="w-nav-brand w--current"><img src="/static/images/logo.png" loading="lazy" alt="" class="navbar__logo" style="height: 34px; width: auto;" /></a>
         <div>
           <nav role="navigation" class="nav-menu w-nav-menu">
+            <span class="nav-link w-nav-link" style="margin-bottom: -5px;">
+              <a class="github-button" href="https://github.com/gchristov/thecodinglove-kotlinjs" data-size="large" data-show-count="true" aria-label="Star gchristov/thecodinglove-kotlinjs on GitHub">Star</a>
+            </span>
             <a href="/support" class="nav-link w-nav-link">Support</a>
             <a href="/terms" class="nav-link w-nav-link">Terms of Service</a>
             <a href="/privacy-policy" class="nav-link w-nav-link">Privacy Policy</a>
@@ -87,7 +90,7 @@
         <div class="m-t-60">
           <div class="m-p-30">
             <h4>About our Terms of Service<br /></h4>
-            <p class="p-small">The following terms and conditions govern all access to and use of the services offered by The Coding Love GIFs, including but not limited to the thecodinglove.gchristov.com web application (“Website”), and service (together, the “The Coding Love GIFs Service”) including all content, services and products available at or through The Coding Love GIFs Service (collectively, the “Services”).<br /><br />Our Services are offered subject to your acceptance of the terms and conditions contained herein and all other operating rules, policies and procedures that may be published from time to time on the Website (collectively, the “Agreement”).<br /><br />Please read the Agreement carefully before accessing or using our Services. By accessing or using any part of our Services, you agree to become bound by the terms and conditions of the Agreement. If you access or use the Services as an employee, consultant or agent of a company or other entity, you represent that you are an employee, consultant or agent of that company or entity, and that you have the authority to bind that company or entity to this Agreement. If you do not agree to all the terms and conditions of the Agreement, then you may not access or use our Services.<br /></p>
+            <p class="p-small">The following terms and conditions govern all access to and use of the services offered by The Coding Love GIFs, including but not limited to the thecodinglove.crowdstandout.com web application (“Website”), and service (together, the “The Coding Love GIFs Service”) including all content, services and products available at or through The Coding Love GIFs Service (collectively, the “Services”).<br /><br />Our Services are offered subject to your acceptance of the terms and conditions contained herein and all other operating rules, policies and procedures that may be published from time to time on the Website (collectively, the “Agreement”).<br /><br />Please read the Agreement carefully before accessing or using our Services. By accessing or using any part of our Services, you agree to become bound by the terms and conditions of the Agreement. If you access or use the Services as an employee, consultant or agent of a company or other entity, you represent that you are an employee, consultant or agent of that company or entity, and that you have the authority to bind that company or entity to this Agreement. If you do not agree to all the terms and conditions of the Agreement, then you may not access or use our Services.<br /></p>
           </div>
           <h3>The Coding Love GIFs &amp; Slack<br /></h3>
           <div class="m-p-30">
@@ -187,5 +190,6 @@
     </div>
     <script src="/static/js/jquery-3.5.1.min.js" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
     <script src="/static/js/contact.js" type="text/javascript" crossorigin="anonymous"></script>
+    <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>
 </html>


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR
- adds the GitHub repo star button to the website
- fixes some incorrect HTML social metadata links

## Screenshots

<img width="525" alt="Screenshot 2023-12-20 at 00 01 03" src="https://github.com/gchristov/thecodinglove-kotlinjs/assets/7644787/a629c557-de3d-40cb-8a0e-253d754fbf73">

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
