### PR TITLE
Add statistics endpoint

### DIFF
--- a/backend/appBackend/build.gradle.kts
+++ b/backend/appBackend/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
                 implementation(projects.search)
                 implementation(projects.selfDestruct)
                 implementation(projects.slack)
+                implementation(projects.statistics)
                 implementation(projects.monitoringData)
                 implementation(projects.htmlParseData)
             }

--- a/backend/appBackend/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMain.kt
+++ b/backend/appBackend/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMain.kt
@@ -32,6 +32,7 @@ import com.gchristov.thecodinglove.slack.slashcommand.SlackSlashCommandPubSubHan
 import com.gchristov.thecodinglove.slackdata.SlackDataModule
 import com.gchristov.thecodinglove.statistics.StatisticsHttpHandler
 import com.gchristov.thecodinglove.statistics.StatisticsModule
+import com.gchristov.thecodinglove.statisticsdata.StatisticsDataModule
 
 suspend fun main() {
     setupDi()
@@ -64,6 +65,7 @@ private fun setupDi(): Either<Throwable, Unit> {
             SlackModule.module,
             SlackDataModule.module,
             StatisticsModule.module,
+            StatisticsDataModule.module,
         )
     )
     return Either.Right(Unit)

--- a/backend/appBackend/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMain.kt
+++ b/backend/appBackend/src/jsMain/kotlin/com/gchristov/thecodinglove/JavascriptMain.kt
@@ -30,6 +30,8 @@ import com.gchristov.thecodinglove.slack.interactivity.SlackInteractivityPubSubH
 import com.gchristov.thecodinglove.slack.slashcommand.SlackSlashCommandHttpHandler
 import com.gchristov.thecodinglove.slack.slashcommand.SlackSlashCommandPubSubHandler
 import com.gchristov.thecodinglove.slackdata.SlackDataModule
+import com.gchristov.thecodinglove.statistics.StatisticsHttpHandler
+import com.gchristov.thecodinglove.statistics.StatisticsModule
 
 suspend fun main() {
     setupDi()
@@ -61,6 +63,7 @@ private fun setupDi(): Either<Throwable, Unit> {
             SelfDestructModule.module,
             SlackModule.module,
             SlackDataModule.module,
+            StatisticsModule.module,
         )
     )
     return Either.Right(Unit)
@@ -99,6 +102,7 @@ private suspend fun setupAppService(): Either<Throwable, HttpService> {
         DiGraph.inject<SlackAuthHttpHandler>(),
         DiGraph.inject<SlackEventHttpHandler>(),
         DiGraph.inject<SelfDestructHttpHandler>(),
+        DiGraph.inject<StatisticsHttpHandler>(),
         // Link this last so that API handlers are correctly registered
         StaticFileHttpHandler("$staticWebsiteRoot/index.html"),
     )

--- a/backend/common-firebase-data/src/commonMain/kotlin/com/gchristov/thecodinglove/commonfirebasedata/CommonFirebaseDataModule.kt
+++ b/backend/common-firebase-data/src/commonMain/kotlin/com/gchristov/thecodinglove/commonfirebasedata/CommonFirebaseDataModule.kt
@@ -1,8 +1,15 @@
 package com.gchristov.thecodinglove.commonfirebasedata
 
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.commonfirebasedata.firestore.FirestoreMigration
+import com.gchristov.thecodinglove.commonfirebasedata.firestore.ScratchMigration
+import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
 import com.gchristov.thecodinglove.commonkotlin.di.DiModule
+import kotlinx.coroutines.Dispatchers
 import org.kodein.di.DI
+import org.kodein.di.bindProvider
 import org.kodein.di.bindSingleton
+import org.kodein.di.instance
 
 object CommonFirebaseDataModule : DiModule() {
     override fun name() = "common-firebase-data"
@@ -10,7 +17,28 @@ object CommonFirebaseDataModule : DiModule() {
     override fun bindDependencies(builder: DI.Builder) {
         builder.apply {
             bindSingleton { provideFirebaseAdmin() }
+            bindProvider {
+                provideFirestoreMigrations(
+                    log = instance(),
+                    firebaseAdmin = instance(),
+                    jsonSerializer = instance(),
+                )
+            }
         }
     }
+
+    private fun provideFirestoreMigrations(
+        log: Logger,
+        firebaseAdmin: FirebaseAdmin,
+        jsonSerializer: JsonSerializer.ExplicitNulls,
+    ): List<FirestoreMigration> = listOf(
+        ScratchMigration(
+            dispatcher = Dispatchers.Default,
+            log = log,
+            firebaseAdmin = firebaseAdmin,
+            jsonSerializer = jsonSerializer,
+        )
+    )
 }
+
 expect fun provideFirebaseAdmin(): FirebaseAdmin

--- a/backend/common-firebase-data/src/commonMain/kotlin/com/gchristov/thecodinglove/commonfirebasedata/firestore/FirestoreMigration.kt
+++ b/backend/common-firebase-data/src/commonMain/kotlin/com/gchristov/thecodinglove/commonfirebasedata/firestore/FirestoreMigration.kt
@@ -1,0 +1,37 @@
+package com.gchristov.thecodinglove.commonfirebasedata.firestore
+
+import arrow.core.Either
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.commonfirebasedata.FirebaseAdmin
+import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+interface FirestoreMigration {
+    suspend fun invoke(): Either<Throwable, Unit>
+}
+
+/**
+ * As of now, Firestore doesn't natively support migrations, so we have to manually perform them if needed. This
+ * scratch file provides a template to do that, which will be run once every time the server restarts. To add a
+ * migration you can:
+ *
+ * 1. Use the [firebaseAdmin] instance to load up data to migrate. Keep in mind that if the domain has changed you may
+ * need to parse the existing data using the old domain models.
+ * 2. Manipulate the data in-memory and prepare it for persistence.
+ * 3. Overwrite the old documents with the new ones, using [FirestoreDocumentReference.set] with merge enabled.
+ */
+@Suppress("unused")
+internal class ScratchMigration(
+    private val dispatcher: CoroutineDispatcher,
+    private val log: Logger,
+    private val firebaseAdmin: FirebaseAdmin,
+    private val jsonSerializer: JsonSerializer,
+) : FirestoreMigration {
+    private val tag = this::class.simpleName
+
+    override suspend fun invoke(): Either<Throwable, Unit> = withContext(dispatcher) {
+        // Write your migration here.
+        Either.Right(Unit)
+    }
+}

--- a/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/domain/SearchSession.kt
+++ b/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/domain/SearchSession.kt
@@ -13,9 +13,11 @@ data class SearchSession(
     val state: State
 ) {
     sealed class State {
-        data object Searching : State()
-        data object Sent : State()
-        data object SelfDestruct : State()
+        abstract val type: String
+
+        data class Searching(override val type: String = "searching") : State()
+        data class Sent(override val type: String = "sent") : State()
+        data class SelfDestruct(override val type: String = "self-destruct") : State()
     }
 }
 
@@ -36,7 +38,7 @@ internal fun DbSearchSession.toSearchSession() = SearchSession(
 )
 
 private fun DbSearchSession.DbState.toSearchSessionState(): SearchSession.State = when (this) {
-    is DbSearchSession.DbState.Searching -> SearchSession.State.Searching
-    is DbSearchSession.DbState.Sent -> SearchSession.State.Sent
-    is DbSearchSession.DbState.SelfDestruct -> SearchSession.State.SelfDestruct
+    is DbSearchSession.DbState.Searching -> SearchSession.State.Searching()
+    is DbSearchSession.DbState.Sent -> SearchSession.State.Sent()
+    is DbSearchSession.DbState.SelfDestruct -> SearchSession.State.SelfDestruct()
 }

--- a/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/usecase/SearchUseCase.kt
+++ b/backend/search-data/src/commonMain/kotlin/com/gchristov/thecodinglove/searchdata/usecase/SearchUseCase.kt
@@ -130,7 +130,7 @@ private suspend fun SearchUseCase.Type.getSearchSession(
             searchHistory = emptyMap(),
             currentPost = null,
             preloadedPost = null,
-            state = SearchSession.State.Searching
+            state = SearchSession.State.Searching()
         )
     )
 

--- a/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealPreloadSearchResultUseCaseTest.kt
+++ b/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealPreloadSearchResultUseCaseTest.kt
@@ -89,7 +89,7 @@ class RealPreloadSearchResultUseCaseTest {
                     searchHistory = searchSession.searchHistory,
                     currentPost = searchSession.currentPost,
                     preloadedPost = null,
-                    state = SearchSession.State.Searching
+                    state = SearchSession.State.Searching()
                 )
             )
             assertEquals(
@@ -122,7 +122,7 @@ class RealPreloadSearchResultUseCaseTest {
                     searchHistory = mapOf(1 to listOf(0, -1)),
                     currentPost = searchSession.currentPost,
                     preloadedPost = searchWithHistoryResult.post,
-                    state = SearchSession.State.Searching
+                    state = SearchSession.State.Searching()
                 )
             )
             assertEquals(

--- a/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchUseCaseTest.kt
+++ b/backend/search-data/src/commonTest/kotlin/com/gchristov/thecodinglove/searchdata/usecase/RealSearchUseCaseTest.kt
@@ -148,7 +148,7 @@ class RealSearchUseCaseTest {
                     searchHistory = emptyMap(),
                     currentPost = null,
                     preloadedPost = null,
-                    state = SearchSession.State.Searching
+                    state = SearchSession.State.Searching()
                 )
             )
         }
@@ -189,7 +189,7 @@ class RealSearchUseCaseTest {
                     searchHistory = mapOf(1 to listOf(0, -1)),
                     currentPost = searchWithHistoryResult.post,
                     preloadedPost = null,
-                    state = SearchSession.State.Searching
+                    state = SearchSession.State.Searching()
                 )
             )
             pubSub.assertEquals(

--- a/backend/search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/searchtestfixtures/FakeSearchRepository.kt
+++ b/backend/search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/searchtestfixtures/FakeSearchRepository.kt
@@ -49,6 +49,10 @@ class FakeSearchRepository(
         TODO("Not yet implemented")
     }
 
+    override suspend fun findSearchSessions(state: SearchSession.State): Either<Throwable, List<SearchSession>> {
+        TODO("Not yet implemented")
+    }
+
     fun assertSessionFetched() {
         assertTrue(searchSessionGetCalled)
     }

--- a/backend/search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/searchtestfixtures/SearchSessionCreator.kt
+++ b/backend/search-testfixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/searchtestfixtures/SearchSessionCreator.kt
@@ -16,6 +16,6 @@ object SearchSessionCreator {
         searchHistory = searchHistory,
         currentPost = null,
         preloadedPost = preloadedPost,
-        state = SearchSession.State.Searching
+        state = SearchSession.State.Searching()
     )
 }

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackAuthUseCase.kt
@@ -20,7 +20,7 @@ interface SlackAuthUseCase {
     }
 }
 
-class RealSlackAuthUseCase(
+internal class RealSlackAuthUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val slackConfig: SlackConfig,
     private val log: Logger,

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackCancelSearchUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackCancelSearchUseCase.kt
@@ -17,7 +17,7 @@ interface SlackCancelSearchUseCase {
     ): Either<Throwable, Unit>
 }
 
-class RealSlackCancelSearchUseCase(
+internal class RealSlackCancelSearchUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val log: Logger,
     private val searchRepository: SearchRepository,

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackRevokeTokensUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackRevokeTokensUseCase.kt
@@ -14,7 +14,7 @@ interface SlackRevokeTokensUseCase {
     suspend operator fun invoke(event: SlackEvent.Callback.Event.TokensRevoked): Either<Throwable, Unit>
 }
 
-class RealSlackRevokeTokensUseCase(
+internal class RealSlackRevokeTokensUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val log: Logger,
     private val slackRepository: SlackRepository,

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
@@ -144,8 +144,8 @@ internal class RealSlackSendSearchUseCase(
                     ).flatMap { messageTs ->
                         val logPlaceholder = selfDestructMinutes?.let { "self-destruct" } ?: "sent"
                         val state = selfDestructMinutes?.let {
-                            SearchSession.State.SelfDestruct
-                        } ?: SearchSession.State.Sent
+                            SearchSession.State.SelfDestruct()
+                        } ?: SearchSession.State.Sent()
                         log.debug(tag, "Marking search session as $logPlaceholder: searchSessionId=$searchSessionId")
                         searchRepository
                             .saveSearchSession(searchSession.copy(state = state))

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackSendSearchUseCase.kt
@@ -31,7 +31,7 @@ interface SlackSendSearchUseCase {
     ): Either<Throwable, Unit>
 }
 
-class RealSlackSendSearchUseCase(
+internal class RealSlackSendSearchUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val log: Logger,
     private val searchRepository: SearchRepository,

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackShuffleSearchUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackShuffleSearchUseCase.kt
@@ -17,7 +17,7 @@ interface SlackShuffleSearchUseCase {
     ): Either<Throwable, Unit>
 }
 
-class RealSlackShuffleSearchUseCase(
+internal class RealSlackShuffleSearchUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val log: Logger,
     private val searchUseCase: SearchUseCase,

--- a/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackVerifyRequestUseCase.kt
+++ b/backend/slack-data/src/commonMain/kotlin/com/gchristov/thecodinglove/slackdata/usecase/SlackVerifyRequestUseCase.kt
@@ -29,7 +29,7 @@ interface SlackVerifyRequestUseCase {
     }
 }
 
-class RealSlackVerifyRequestUseCase(
+internal class RealSlackVerifyRequestUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val slackConfig: SlackConfig,
     private val clock: Clock,

--- a/backend/statistics-data/build.gradle.kts
+++ b/backend/statistics-data/build.gradle.kts
@@ -1,12 +1,13 @@
 plugins {
-    id("backend-service-plugin")
+    id("data-plugin")
 }
 
 kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                api(projects.statisticsData)
+                implementation(projects.slackData)
+                implementation(projects.searchData)
             }
         }
     }

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/StatisticsDataModule.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/StatisticsDataModule.kt
@@ -1,0 +1,39 @@
+package com.gchristov.thecodinglove.statisticsdata
+
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.commonkotlin.di.DiModule
+import com.gchristov.thecodinglove.searchdata.SearchRepository
+import com.gchristov.thecodinglove.slackdata.SlackRepository
+import com.gchristov.thecodinglove.statisticsdata.usecase.RealStatisticsReportUseCase
+import com.gchristov.thecodinglove.statisticsdata.usecase.StatisticsReportUseCase
+import kotlinx.coroutines.Dispatchers
+import org.kodein.di.DI
+import org.kodein.di.bindProvider
+import org.kodein.di.instance
+
+object StatisticsDataModule : DiModule() {
+    override fun name() = "statistics-data"
+
+    override fun bindDependencies(builder: DI.Builder) {
+        builder.apply {
+            bindProvider {
+                provideStatisticsReportUseCase(
+                    log = instance(),
+                    searchRepository = instance(),
+                    slackRepository = instance(),
+                )
+            }
+        }
+    }
+
+    private fun provideStatisticsReportUseCase(
+        log: Logger,
+        searchRepository: SearchRepository,
+        slackRepository: SlackRepository,
+    ): StatisticsReportUseCase = RealStatisticsReportUseCase(
+        dispatcher = Dispatchers.Default,
+        log = log,
+        searchRepository = searchRepository,
+        slackRepository = slackRepository,
+    )
+}

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/api/ApiStatisticsReport.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/api/ApiStatisticsReport.kt
@@ -1,0 +1,24 @@
+package com.gchristov.thecodinglove.statisticsdata.api
+
+import com.gchristov.thecodinglove.statisticsdata.domain.StatisticsReport
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ApiStatisticsReport(
+    @SerialName("messages_sent") val messagesSent: Int,
+    @SerialName("messages_searching") val messagesSearching: Int,
+    @SerialName("messages_self_destruct") val messagesSelfDestruct: Int,
+    @SerialName("active_self_destruct_messages") val activeSelfDestructMessages: Int,
+    @SerialName("user_tokens") val userTokens: Int,
+    @SerialName("teams") val teams: Int,
+)
+
+fun StatisticsReport.toStatisticsReport() = ApiStatisticsReport(
+    messagesSent = messagesSent,
+    messagesSearching = messagesSearching,
+    messagesSelfDestruct = messagesSelfDestruct,
+    activeSelfDestructMessages = activeSelfDestructMessages,
+    userTokens = userTokens,
+    teams = teams,
+)

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/api/ApiStatisticsReport.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/api/ApiStatisticsReport.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ApiStatisticsReport(
     @SerialName("messages_sent") val messagesSent: Int,
-    @SerialName("messages_searching") val messagesSearching: Int,
+    @SerialName("active_search_sessions") val activeSearchSessions: Int,
     @SerialName("messages_self_destruct") val messagesSelfDestruct: Int,
     @SerialName("active_self_destruct_messages") val activeSelfDestructMessages: Int,
     @SerialName("user_tokens") val userTokens: Int,
@@ -16,7 +16,7 @@ data class ApiStatisticsReport(
 
 fun StatisticsReport.toStatisticsReport() = ApiStatisticsReport(
     messagesSent = messagesSent,
-    messagesSearching = messagesSearching,
+    activeSearchSessions = activeSearchSessions,
     messagesSelfDestruct = messagesSelfDestruct,
     activeSelfDestructMessages = activeSelfDestructMessages,
     userTokens = userTokens,

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/domain/StatisticsReport.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/domain/StatisticsReport.kt
@@ -1,0 +1,10 @@
+package com.gchristov.thecodinglove.statisticsdata.domain
+
+data class StatisticsReport(
+    val messagesSent: Int,
+    val messagesSearching: Int,
+    val messagesSelfDestruct: Int,
+    val activeSelfDestructMessages: Int,
+    val userTokens: Int,
+    val teams: Int,
+)

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/domain/StatisticsReport.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/domain/StatisticsReport.kt
@@ -2,7 +2,7 @@ package com.gchristov.thecodinglove.statisticsdata.domain
 
 data class StatisticsReport(
     val messagesSent: Int,
-    val messagesSearching: Int,
+    val activeSearchSessions: Int,
     val messagesSelfDestruct: Int,
     val activeSelfDestructMessages: Int,
     val userTokens: Int,

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/usecase/StatisticsReportUseCase.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/usecase/StatisticsReportUseCase.kt
@@ -1,0 +1,35 @@
+package com.gchristov.thecodinglove.statisticsdata.usecase
+
+import arrow.core.Either
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.searchdata.SearchRepository
+import com.gchristov.thecodinglove.slackdata.SlackRepository
+import com.gchristov.thecodinglove.statisticsdata.domain.StatisticsReport
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+interface StatisticsReportUseCase {
+    suspend operator fun invoke(): Either<Throwable, StatisticsReport>
+}
+
+internal class RealStatisticsReportUseCase(
+    private val dispatcher: CoroutineDispatcher,
+    private val log: Logger,
+    private val slackRepository: SlackRepository,
+    private val searchRepository: SearchRepository,
+) : StatisticsReportUseCase {
+    private val tag = this::class.simpleName
+
+    override suspend fun invoke(): Either<Throwable, StatisticsReport> = withContext(dispatcher) {
+        Either.Right(
+            StatisticsReport(
+                messagesSent = 0,
+                messagesSearching = 0,
+                messagesSelfDestruct = 0,
+                activeSelfDestructMessages = 0,
+                userTokens = 0,
+                teams = 0,
+            )
+        )
+    }
+}

--- a/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/usecase/StatisticsReportUseCase.kt
+++ b/backend/statistics-data/src/commonMain/kotlin/com/gchristov/thecodinglove/statisticsdata/usecase/StatisticsReportUseCase.kt
@@ -39,7 +39,7 @@ internal class RealStatisticsReportUseCase(
                                         Either.Right(
                                             StatisticsReport(
                                                 messagesSent = sentMessages.size,
-                                                messagesSearching = activeSearchSessions.size,
+                                                activeSearchSessions = activeSearchSessions.size,
                                                 messagesSelfDestruct = selfDestructMessages.size,
                                                 activeSelfDestructMessages = activeSelfDestructMessages.size,
                                                 userTokens = 0,

--- a/backend/statistics/build.gradle.kts
+++ b/backend/statistics/build.gradle.kts
@@ -7,6 +7,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(projects.slackData)
+                implementation(projects.searchData)
             }
         }
     }

--- a/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsHttpHandler.kt
+++ b/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsHttpHandler.kt
@@ -1,20 +1,24 @@
 package com.gchristov.thecodinglove.statistics
 
 import arrow.core.Either
+import arrow.core.flatMap
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
 import com.gchristov.thecodinglove.commonservice.BaseHttpHandler
 import com.gchristov.thecodinglove.commonservicedata.http.HttpHandler
 import com.gchristov.thecodinglove.commonservicedata.http.HttpRequest
 import com.gchristov.thecodinglove.commonservicedata.http.HttpResponse
-import com.gchristov.thecodinglove.commonservicedata.http.sendEmpty
+import com.gchristov.thecodinglove.commonservicedata.http.sendJson
+import com.gchristov.thecodinglove.statisticsdata.api.toStatisticsReport
+import com.gchristov.thecodinglove.statisticsdata.usecase.StatisticsReportUseCase
 import io.ktor.http.*
 import kotlinx.coroutines.CoroutineDispatcher
 
 class StatisticsHttpHandler(
     dispatcher: CoroutineDispatcher,
-    jsonSerializer: JsonSerializer,
+    private val jsonSerializer: JsonSerializer,
     log: Logger,
+    private val statisticsReportUseCase: StatisticsReportUseCase,
 ) : BaseHttpHandler(
     dispatcher = dispatcher,
     jsonSerializer = jsonSerializer,
@@ -29,5 +33,10 @@ class StatisticsHttpHandler(
     override suspend fun handleHttpRequestAsync(
         request: HttpRequest,
         response: HttpResponse,
-    ): Either<Throwable, Unit> = response.sendEmpty()
+    ): Either<Throwable, Unit> = statisticsReportUseCase().flatMap { report ->
+        response.sendJson(
+            data = report.toStatisticsReport(),
+            jsonSerializer = jsonSerializer,
+        )
+    }
 }

--- a/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsHttpHandler.kt
+++ b/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsHttpHandler.kt
@@ -1,0 +1,33 @@
+package com.gchristov.thecodinglove.statistics
+
+import arrow.core.Either
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
+import com.gchristov.thecodinglove.commonservice.BaseHttpHandler
+import com.gchristov.thecodinglove.commonservicedata.http.HttpHandler
+import com.gchristov.thecodinglove.commonservicedata.http.HttpRequest
+import com.gchristov.thecodinglove.commonservicedata.http.HttpResponse
+import com.gchristov.thecodinglove.commonservicedata.http.sendEmpty
+import io.ktor.http.*
+import kotlinx.coroutines.CoroutineDispatcher
+
+class StatisticsHttpHandler(
+    dispatcher: CoroutineDispatcher,
+    jsonSerializer: JsonSerializer,
+    log: Logger,
+) : BaseHttpHandler(
+    dispatcher = dispatcher,
+    jsonSerializer = jsonSerializer,
+    log = log,
+) {
+    override fun httpConfig() = HttpHandler.HttpConfig(
+        method = HttpMethod.Get,
+        path = "/api/stats",
+        contentType = ContentType.Application.Json,
+    )
+
+    override suspend fun handleHttpRequestAsync(
+        request: HttpRequest,
+        response: HttpResponse,
+    ): Either<Throwable, Unit> = response.sendEmpty()
+}

--- a/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsModule.kt
+++ b/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsModule.kt
@@ -1,0 +1,33 @@
+package com.gchristov.thecodinglove.statistics
+
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
+import com.gchristov.thecodinglove.commonkotlin.di.DiModule
+import kotlinx.coroutines.Dispatchers
+import org.kodein.di.DI
+import org.kodein.di.bindSingleton
+import org.kodein.di.instance
+
+object StatisticsModule : DiModule() {
+    override fun name() = "statistics"
+
+    override fun bindDependencies(builder: DI.Builder) {
+        builder.apply {
+            bindSingleton {
+                provideStatisticsHttpHandler(
+                    jsonSerializer = instance(),
+                    log = instance(),
+                )
+            }
+        }
+    }
+
+    private fun provideStatisticsHttpHandler(
+        jsonSerializer: JsonSerializer.Default,
+        log: Logger,
+    ): StatisticsHttpHandler = StatisticsHttpHandler(
+        dispatcher = Dispatchers.Default,
+        jsonSerializer = jsonSerializer,
+        log = log,
+    )
+}

--- a/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsModule.kt
+++ b/backend/statistics/src/commonMain/kotlin/com/gchristov/thecodinglove/statistics/StatisticsModule.kt
@@ -3,6 +3,7 @@ package com.gchristov.thecodinglove.statistics
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.commonkotlin.JsonSerializer
 import com.gchristov.thecodinglove.commonkotlin.di.DiModule
+import com.gchristov.thecodinglove.statisticsdata.usecase.StatisticsReportUseCase
 import kotlinx.coroutines.Dispatchers
 import org.kodein.di.DI
 import org.kodein.di.bindSingleton
@@ -17,6 +18,7 @@ object StatisticsModule : DiModule() {
                 provideStatisticsHttpHandler(
                     jsonSerializer = instance(),
                     log = instance(),
+                    statisticsReportUseCase = instance(),
                 )
             }
         }
@@ -25,9 +27,11 @@ object StatisticsModule : DiModule() {
     private fun provideStatisticsHttpHandler(
         jsonSerializer: JsonSerializer.Default,
         log: Logger,
+        statisticsReportUseCase: StatisticsReportUseCase,
     ): StatisticsHttpHandler = StatisticsHttpHandler(
         dispatcher = Dispatchers.Default,
         jsonSerializer = jsonSerializer,
         log = log,
+        statisticsReportUseCase = statisticsReportUseCase,
     )
 }

--- a/modules.gradle.kts
+++ b/modules.gradle.kts
@@ -20,6 +20,7 @@ val projects = listOf(
     "backend/slack-data",
     "backend/slack-testfixtures",
     "backend/statistics",
+    "backend/statistics-data",
     "client/appWeb/appWeb",
 )
 

--- a/modules.gradle.kts
+++ b/modules.gradle.kts
@@ -19,6 +19,7 @@ val projects = listOf(
     "backend/slack",
     "backend/slack-data",
     "backend/slack-testfixtures",
+    "backend/statistics",
     "client/appWeb/appWeb",
 )
 


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR:
- adds a new `/api/stats` endpoint for some usage statistics
- adds a framework for simple Firestore migrations

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
