### PR TITLE
Point PubSub to slack-service

### DIFF
--- a/pulumi/Pulumi.yaml
+++ b/pulumi/Pulumi.yaml
@@ -628,7 +628,7 @@ resources:
       messageRetentionDuration: 600s
       name: slack_interactivity_subscription
       pushConfig:
-        pushEndpoint: ${app-service.uri}/api/pubsub/slack/interactivity
+        pushEndpoint: ${slack-service.uri}/api/pubsub/slack/interactivity
       retryPolicy:
         maximumBackoff: 600s
         minimumBackoff: 10s
@@ -677,7 +677,7 @@ resources:
       messageRetentionDuration: 600s
       name: slack_slash_command_subscription
       pushConfig:
-        pushEndpoint: ${app-service.uri}/api/pubsub/slack/slash
+        pushEndpoint: ${slack-service.uri}/api/pubsub/slack/slash
       retryPolicy:
         maximumBackoff: 600s
         minimumBackoff: 10s


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

Fixes PubSub to point to the new service.

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
