### PR TITLE
Fix handler for empty search results

### DIFF
--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchHttpHandler.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchHttpHandler.kt
@@ -31,6 +31,24 @@ class SearchHttpHandler(
         contentType = ContentType.Application.Json,
     )
 
+    override fun handleError(
+        error: Throwable,
+        response: HttpResponse,
+    ): Either<Throwable, Unit> {
+        return if (error is SearchUseCase.Error) {
+            when (error) {
+                // Empty search results are expected so we respond with 200 and relevant error type.
+                is SearchUseCase.Error.Empty -> response.sendJson(
+                    data = error.toSearchResult(),
+                    jsonSerializer = jsonSerializer,
+                )
+                is SearchUseCase.Error.SessionNotFound -> super.handleError(error, response)
+            }
+        } else {
+            super.handleError(error, response)
+        }
+    }
+
     override suspend fun handleHttpRequestAsync(
         request: HttpRequest,
         response: HttpResponse,

--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchResultMapper.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchResultMapper.kt
@@ -4,15 +4,25 @@ import com.gchristov.thecodinglove.search.domain.model.SearchPost
 import com.gchristov.thecodinglove.search.domain.usecase.SearchUseCase
 import com.gchristov.thecodinglove.search.proto.http.model.ApiSearchResult
 
+internal fun SearchUseCase.Error.Empty.toSearchResult() = ApiSearchResult(
+    ok = false,
+    error = ApiSearchResult.ApiError.NoResults,
+    searchSession = null,
+)
+
 internal fun SearchUseCase.Result.toSearchResult() = ApiSearchResult(
-    searchSessionId = searchSessionId,
-    query = query,
-    post = post.toPost(),
-    totalPosts = totalPosts
+    ok = true,
+    error = null,
+    searchSession = ApiSearchResult.ApiSearchSession(
+        searchSessionId = searchSessionId,
+        query = query,
+        post = post.toPost(),
+        totalPosts = totalPosts,
+    )
 )
 
 private fun SearchPost.toPost() = ApiSearchResult.ApiPost(
     title = title,
     url = url,
-    imageUrl = imageUrl
+    imageUrl = imageUrl,
 )

--- a/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchHttpHandlerTest.kt
+++ b/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchHttpHandlerTest.kt
@@ -91,7 +91,7 @@ class SearchHttpHandlerTest {
                 header = "Content-Type",
                 headerValue = ContentType.Application.Json.toString(),
                 data = """
-                        {"search_session_id":"session_123","query":"test","post":{"title":"post","url":"url","image_url":"imageUrl"},"total_posts":1}
+                        {"ok":true,"search_session":{"search_session_id":"session_123","query":"test","total_posts":1,"post":{"title":"post","url":"url","image_url":"imageUrl"}}}
                        """.trimIndent(),
                 status = 200,
                 filePath = null,
@@ -160,8 +160,10 @@ class SearchHttpHandlerTest {
         response.assertEquals(
             header = "Content-Type",
             headerValue = ContentType.Application.Json.toString(),
-            data = "{\"errorMessage\":\"No results found: test\"}",
-            status = 400,
+            data = """
+                {"ok":false,"error":{"type":"no-results"}}
+            """.trimIndent(),
+            status = 200,
             filePath = null,
         )
     }
@@ -179,7 +181,9 @@ class SearchHttpHandlerTest {
         response.assertEquals(
             header = "Content-Type",
             headerValue = ContentType.Application.Json.toString(),
-            data = "{\"errorMessage\":\"Session not found: test\"}",
+            data = """
+                {"errorMessage":"Session not found: test"}
+            """.trimIndent(),
             status = 400,
             filePath = null,
         )

--- a/search/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/search/domain/SearchDomainModule.kt
+++ b/search/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/search/domain/SearchDomainModule.kt
@@ -25,6 +25,7 @@ object SearchDomainModule : DiModule() {
                 provideSearchUseCase(
                     searchRepository = instance(),
                     searchWithHistoryUseCase = instance(),
+                    log = instance(),
                 )
             }
             bindProvider {
@@ -55,10 +56,12 @@ object SearchDomainModule : DiModule() {
     private fun provideSearchUseCase(
         searchRepository: SearchRepository,
         searchWithHistoryUseCase: SearchWithHistoryUseCase,
+        log: Logger,
     ): SearchUseCase = RealSearchUseCase(
         dispatcher = Dispatchers.Default,
         searchRepository = searchRepository,
         searchWithHistoryUseCase = searchWithHistoryUseCase,
+        log = log,
     )
 
     private fun providePreloadSearchResultUseCase(

--- a/search/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/search/domain/usecase/SearchUseCase.kt
+++ b/search/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/search/domain/usecase/SearchUseCase.kt
@@ -2,7 +2,9 @@ package com.gchristov.thecodinglove.search.domain.usecase
 
 import arrow.core.Either
 import arrow.core.flatMap
+import co.touchlab.kermit.Logger
 import com.benasher44.uuid.uuid4
+import com.gchristov.thecodinglove.common.kotlin.debug
 import com.gchristov.thecodinglove.search.domain.model.SearchPost
 import com.gchristov.thecodinglove.search.domain.model.SearchSession
 import com.gchristov.thecodinglove.search.domain.model.insert
@@ -44,7 +46,10 @@ internal class RealSearchUseCase(
     private val dispatcher: CoroutineDispatcher,
     private val searchRepository: SearchRepository,
     private val searchWithHistoryUseCase: SearchWithHistoryUseCase,
+    private val log: Logger,
 ) : SearchUseCase {
+    private val tag = this::class.simpleName
+
     override suspend operator fun invoke(
         dto: SearchUseCase.Dto
     ): Either<SearchUseCase.Error, SearchUseCase.Result> = withContext(dispatcher) {
@@ -53,6 +58,7 @@ internal class RealSearchUseCase(
             .flatMap { searchSession ->
                 val preloadedPost = searchSession.preloadedPost
                 if (preloadedPost != null) {
+                    log.debug(tag, "Using preloaded post")
                     // If a post is preloaded, use it right away
                     searchSession.usePreloadedPost(
                         preloadedPost = preloadedPost,
@@ -68,6 +74,7 @@ internal class RealSearchUseCase(
                             )
                         }
                 } else {
+                    log.debug(tag, "No preloaded post, running normal search")
                     // Else, run normal search
                     searchWithHistoryUseCase(
                         SearchWithHistoryUseCase.Dto(

--- a/search/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/search/domain/usecase/RealSearchUseCaseTest.kt
+++ b/search/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/search/domain/usecase/RealSearchUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.gchristov.thecodinglove.search.domain.usecase
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.common.test.FakeCoroutineDispatcher
+import com.gchristov.thecodinglove.common.test.FakeLogger
 import com.gchristov.thecodinglove.search.domain.model.SearchSession
 import com.gchristov.thecodinglove.search.testfixtures.*
 import kotlinx.coroutines.test.TestResult
@@ -202,6 +203,7 @@ class RealSearchUseCaseTest {
             dispatcher = FakeCoroutineDispatcher,
             searchRepository = searchRepository,
             searchWithHistoryUseCase = searchWithHistoryUseCase,
+            log = FakeLogger,
         )
         testBlock(useCase, searchRepository, searchWithHistoryUseCase)
     }

--- a/search/proto/src/commonMain/kotlin/com/gchristov/thecodinglove/search/proto/http/model/ApiSearchResult.kt
+++ b/search/proto/src/commonMain/kotlin/com/gchristov/thecodinglove/search/proto/http/model/ApiSearchResult.kt
@@ -5,11 +5,25 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ApiSearchResult(
-    @SerialName("search_session_id") val searchSessionId: String,
-    @SerialName("query") val query: String,
-    @SerialName("post") val post: ApiPost,
-    @SerialName("total_posts") val totalPosts: Int
+    @SerialName("ok") val ok: Boolean,
+    @SerialName("error") val error: ApiError?,
+    @SerialName("search_session") val searchSession: ApiSearchSession?,
 ) {
+    @Serializable
+    sealed class ApiError {
+        @Serializable
+        @SerialName("no-results")
+        data object NoResults : ApiError()
+    }
+
+    @Serializable
+    data class ApiSearchSession(
+        @SerialName("search_session_id") val searchSessionId: String,
+        @SerialName("query") val query: String,
+        @SerialName("total_posts") val totalPosts: Int,
+        @SerialName("post") val post: ApiPost,
+    )
+
     @Serializable
     data class ApiPost(
         @SerialName("title") val title: String,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
@@ -61,7 +61,7 @@ class SlackSlashCommandPubSubHandler(
             ifLeft = {
                 slackRepository.postMessageToUrl(
                     url = responseUrl,
-                    message = slackMessageFactory.message(text = GenericError)
+                    message = slackMessageFactory.searchGenericErrorMessage()
                 )
             },
             ifRight = { searchResult ->
@@ -79,20 +79,20 @@ class SlackSlashCommandPubSubHandler(
                         )
                     )
 
-                    else -> {
-                        val text = when (searchResult.error) {
-                            is SlackSearchRepository.SearchResultDto.Error.NoResults -> "No results found for '$text'. Please try a different search query, for example `release`."
-                            null -> GenericError
+                    else -> when (searchResult.error) {
+                        is SlackSearchRepository.SearchResultDto.Error.NoResults -> {
+                            slackRepository.postMessageToUrl(
+                                url = responseUrl,
+                                message = slackMessageFactory.noSearchResultsMessage(text)
+                            )
                         }
-                        slackRepository.postMessageToUrl(
+
+                        null -> slackRepository.postMessageToUrl(
                             url = responseUrl,
-                            message = slackMessageFactory.message(text = text)
+                            message = slackMessageFactory.searchGenericErrorMessage()
                         )
                     }
                 }
             }
         )
 }
-
-private const val GenericError =
-    "⚠️ Something has gone wrong. We have been notified, so please try again while we investigate."

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
@@ -61,7 +61,7 @@ class SlackSlashCommandPubSubHandler(
             ifLeft = {
                 slackRepository.postMessageToUrl(
                     url = responseUrl,
-                    message = slackMessageFactory.message(text = "⚠️ Something has gone wrong. We have been notified, so please try again while we investigate.")
+                    message = slackMessageFactory.message(text = GenericError)
                 )
             },
             ifRight = { searchResult ->
@@ -80,12 +80,19 @@ class SlackSlashCommandPubSubHandler(
                     )
 
                     else -> {
+                        val text = when (searchResult.error) {
+                            is SlackSearchRepository.SearchResultDto.Error.NoResults -> "No results found for '$text'. Please try a different search query, for example `release`."
+                            null -> GenericError
+                        }
                         slackRepository.postMessageToUrl(
                             url = responseUrl,
-                            message = slackMessageFactory.message(text = "No results found for '$text'. Please try a different search query, for example `release`.")
+                            message = slackMessageFactory.message(text = text)
                         )
                     }
                 }
             }
         )
 }
+
+private const val GenericError =
+    "⚠️ Something has gone wrong. We have been notified, so please try again while we investigate."

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSlashCommandPubSubHandler.kt
@@ -6,7 +6,6 @@ import arrow.core.left
 import arrow.core.right
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.common.kotlin.JsonSerializer
-import com.gchristov.thecodinglove.common.kotlin.error
 import com.gchristov.thecodinglove.common.network.http.HttpHandler
 import com.gchristov.thecodinglove.common.pubsub.BasePubSubHandler
 import com.gchristov.thecodinglove.common.pubsub.PubSubDecoder
@@ -48,38 +47,45 @@ class SlackSlashCommandPubSubHandler(
             .flatMap { it?.right() ?: Exception("Request body is invalid").left<Throwable>() }
             .flatMap { it.handle() }
 
+    /*
+     * This method handles errors as success without PubSub retries, but tries to notify the user of the error. If
+     * sending the Slack reply back fails, the entire PubSub chain will be retried automatically. This is to avoid
+     * unnecessary PubSub retries which would most likely result in additional errors if the problem is on our end.
+     */
     private suspend fun PubSubSlackSlashCommandMessage.handle() = slackRepository.postMessageToUrl(
         url = responseUrl,
         message = slackMessageFactory.message("🔎 Hang tight, we're finding your GIF...")
     )
         .flatMap { slackSearchRepository.search(text) }
-        .flatMap { searchResult ->
-            slackRepository.postMessageToUrl(
-                url = responseUrl,
-                message = slackMessageFactory.searchResultMessage(
-                    searchQuery = searchResult.searchQuery,
-                    searchResults = searchResult.searchResults,
-                    searchSessionId = searchResult.searchSessionId,
-                    attachmentTitle = searchResult.attachmentTitle,
-                    attachmentUrl = searchResult.attachmentUrl,
-                    attachmentImageUrl = searchResult.attachmentImageUrl,
-                )
-            )
-        }
         .fold(
             ifLeft = {
-                // Handle errors as success without PubSub retries, but try to notify the user of the error. If sending
-                // the reply back fails, the entire PubSub chain will be retried automatically.
-                log.error(tag, it) { "Error handling request" }
-                val userErrorMessage = when {
-//                    it is SearchError.Empty -> "No results found for '$text'. Please try a different search query."
-                    else -> "⚠️ Something has gone wrong. Please try again while we investigate."
-                }
                 slackRepository.postMessageToUrl(
                     url = responseUrl,
-                    message = slackMessageFactory.message(text = userErrorMessage)
+                    message = slackMessageFactory.message(text = "⚠️ Something has gone wrong. We have been notified, so please try again while we investigate.")
                 )
             },
-            ifRight = { Either.Right(Unit) }
+            ifRight = { searchResult ->
+                val searchSession = searchResult.searchSession
+                when {
+                    searchResult.ok && searchSession != null -> slackRepository.postMessageToUrl(
+                        url = responseUrl,
+                        message = slackMessageFactory.searchResultMessage(
+                            searchQuery = searchSession.post.searchQuery,
+                            searchResults = searchSession.searchResults,
+                            searchSessionId = searchSession.searchSessionId,
+                            attachmentTitle = searchSession.post.attachmentTitle,
+                            attachmentUrl = searchSession.post.attachmentUrl,
+                            attachmentImageUrl = searchSession.post.attachmentImageUrl,
+                        )
+                    )
+
+                    else -> {
+                        slackRepository.postMessageToUrl(
+                            url = responseUrl,
+                            message = slackMessageFactory.message(text = "No results found for '$text'. Please try a different search query, for example `release`.")
+                        )
+                    }
+                }
+            }
         )
 }

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SearchResultMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SearchResultMapper.kt
@@ -4,10 +4,24 @@ import com.gchristov.thecodinglove.search.proto.http.model.ApiSearchResult
 import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 
 internal fun ApiSearchResult.toSearchResult() = SlackSearchRepository.SearchResultDto(
+    ok = ok,
+    error = error?.toSearchError(),
+    searchSession = searchSession?.toSearchSession(),
+)
+
+private fun ApiSearchResult.ApiError.toSearchError() = when (this) {
+    is ApiSearchResult.ApiError.NoResults -> SlackSearchRepository.SearchResultDto.Error.NoResults
+}
+
+private fun ApiSearchResult.ApiSearchSession.toSearchSession() = SlackSearchRepository.SearchResultDto.SearchSession(
     searchSessionId = searchSessionId,
-    searchQuery = query,
     searchResults = totalPosts,
-    attachmentTitle = post.title,
-    attachmentUrl = post.url,
-    attachmentImageUrl = post.imageUrl,
+    post = post.toPost(query)
+)
+
+private fun ApiSearchResult.ApiPost.toPost(query: String) = SlackSearchRepository.SearchSessionPostDto(
+    searchQuery = query,
+    attachmentTitle = title,
+    attachmentUrl = url,
+    attachmentImageUrl = imageUrl,
 )

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
@@ -42,6 +42,10 @@ interface SlackMessageFactory {
         selfDestructMinutes: Int?,
     ): SlackMessage
 
+    fun searchGenericErrorMessage(): SlackMessage
+
+    fun noSearchResultsMessage(query: String): SlackMessage
+
     fun attachment(
         title: String? = null,
         text: String? = null,
@@ -186,6 +190,14 @@ internal class RealSlackMessageFactory(
                     ?: PostedUsingFooter,
             )
         ),
+    )
+
+    override fun searchGenericErrorMessage() = message(
+        text = "⚠️ Something has gone wrong. We have been notified, so please try again while we investigate."
+    )
+
+    override fun noSearchResultsMessage(query: String) = message(
+        text = "No results found for \"$query\". However, here are some popular suggestions for you to try again: \"release\", \"production\", \"test\""
     )
 
     override fun attachment(

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
@@ -17,13 +17,20 @@ interface SlackSearchRepository {
     suspend fun getSearchSessionPost(searchSessionId: String): Either<Throwable, SearchSessionPostDto>
 
     data class SearchResultDto(
-        val searchSessionId: String,
-        val searchQuery: String,
-        val searchResults: Int,
-        val attachmentTitle: String,
-        val attachmentUrl: String,
-        val attachmentImageUrl: String,
-    )
+        val ok: Boolean,
+        val error: Error?,
+        val searchSession: SearchSession?,
+    ) {
+        sealed class Error {
+            data object NoResults : Error()
+        }
+
+        data class SearchSession(
+            val searchSessionId: String,
+            val searchResults: Int,
+            val post: SearchSessionPostDto,
+        )
+    }
 
     sealed class SearchSessionStateDto {
         data object Sent : SearchSessionStateDto()

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackShuffleSearchUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackShuffleSearchUseCase.kt
@@ -4,9 +4,10 @@ import arrow.core.Either
 import arrow.core.flatMap
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.common.kotlin.debug
+import com.gchristov.thecodinglove.common.kotlin.error
 import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
-import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
+import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 
@@ -33,18 +34,33 @@ internal class RealSlackShuffleSearchUseCase(
             log.debug(tag, "Shuffling search result: searchSessionId=${dto.searchSessionId}")
             slackSearchRepository.shuffle(dto.searchSessionId)
                 .flatMap { shuffleResult ->
-                    log.debug(tag, "Sending shuffle response: responseUrl=${dto.responseUrl}")
-                    slackRepository.postMessageToUrl(
-                        url = dto.responseUrl,
-                        message = slackMessageFactory.searchResultMessage(
-                            searchQuery = shuffleResult.searchQuery,
-                            searchResults = shuffleResult.searchResults,
-                            searchSessionId = dto.searchSessionId,
-                            attachmentTitle = shuffleResult.attachmentTitle,
-                            attachmentUrl = shuffleResult.attachmentUrl,
-                            attachmentImageUrl = shuffleResult.attachmentImageUrl,
-                        )
-                    )
+                    when {
+                        shuffleResult.ok && shuffleResult.searchSession != null -> {
+                            log.debug(tag, "Sending shuffle response: responseUrl=${dto.responseUrl}")
+                            slackRepository.postMessageToUrl(
+                                url = dto.responseUrl,
+                                message = slackMessageFactory.searchResultMessage(
+                                    searchQuery = shuffleResult.searchSession.post.searchQuery,
+                                    searchResults = shuffleResult.searchSession.searchResults,
+                                    searchSessionId = shuffleResult.searchSession.searchSessionId,
+                                    attachmentTitle = shuffleResult.searchSession.post.attachmentTitle,
+                                    attachmentUrl = shuffleResult.searchSession.post.attachmentUrl,
+                                    attachmentImageUrl = shuffleResult.searchSession.post.attachmentImageUrl,
+                                )
+                            )
+                        }
+
+                        else -> {
+                            // Swallow but report the error, so that we can investigate. At this point, the user will be seeing
+                            // a post with interactivity options, so from their POV nothing will happen, so they can re-shuffle.
+                            log.error(tag, Throwable(shuffleResult.error?.let {
+                                when (it) {
+                                    is SlackSearchRepository.SearchResultDto.Error.NoResults -> "No results found"
+                                }
+                            } ?: "Unknown error")) { "Error shuffling" }
+                            Either.Right(Unit)
+                        }
+                    }
                 }
         }
 }


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR updates the search result proto definition to be able to handle expected errors, such as no results during a search. This is then used in the `slack` module to report an error to the user.

## Demo

https://github.com/gchristov/thecodinglove-kotlinjs/assets/7644787/c0f26d2f-1f65-4a63-b50e-df1425dee99c

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
