### PR TITLE
Ensure each microservice uses its own build output folder

### DIFF
--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,6 +1,6 @@
 services:
   search-service:
-    build: ../build/services/search-service/.
+    build: ../search/service/build/dist/js
     ports:
       - "8081:8081"
     environment:
@@ -8,21 +8,21 @@ services:
       - API_URL=http://host.docker.internal:8080/api
       - PRELOAD_SEARCH_PUBSUB_TOPIC=preload_search_dev
   statistics-service:
-    build: ../build/services/statistics-service/.
+    build: ../statistics/service/build/dist/js
     ports:
       - "8082:8082"
     environment:
       - PORT=8082
       - API_URL=http://host.docker.internal:8080/api
   self-destruct-service:
-    build: ../build/services/self-destruct-service/.
+    build: ../self-destruct/service/build/dist/js
     ports:
       - "8083:8083"
     environment:
       - PORT=8083
       - API_URL=http://host.docker.internal:8080/api
   slack-service:
-    build: ../build/services/slack-service/.
+    build: ../slack/service/build/dist/js
     ports:
       - "8084:8084"
     environment:
@@ -32,7 +32,7 @@ services:
       - SLACK_SLASH_COMMAND_PUBSUB_TOPIC=slack_slash_command_dev
       - SLACK_INTERACTIVITY_PUBSUB_TOPIC=slack_interactivity_dev
   landing-page-service:
-    build: ../build/services/landing-page-service/.
+    build: ../landing-page/service/build/dist/js
     ports:
       - "8080:80"
     environment:

--- a/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/BackendBinaryPlugin.kt
+++ b/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/BackendBinaryPlugin.kt
@@ -8,7 +8,6 @@ class BackendBinaryPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.run {
             plugins.apply("module-plugin")
-            plugins.apply("dev.petuska.npm.publish")
             extensions.configure(KotlinMultiplatformExtension::class.java) {
                 js(IR) {
                     binaries.library()
@@ -38,15 +37,11 @@ class BackendBinaryPlugin : Plugin<Project> {
                 doLast {
                     copy {
                         from(file(rootProject.layout.projectDirectory.file("credentials-gcp-app.json")))
-                        into(binaryDestination().get().dir("bin").asFile)
-                    }
-                    copy {
-                        from(layout.buildDirectory.dir("packages/js").get().asFile)
-                        into(binaryDestination().get().dir("bin").asFile)
+                        into("${binaryRootDirectory()}/productionExecutable")
                     }
                     copy {
                         from(file(layout.projectDirectory.file("Dockerfile")))
-                        into(binaryDestination().get())
+                        into(binaryRootDirectory())
                     }
                 }
             }

--- a/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/FrontendBinaryPlugin.kt
+++ b/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/FrontendBinaryPlugin.kt
@@ -17,12 +17,8 @@ class FrontendBinaryPlugin : Plugin<Project> {
             tasks.named("assemble") {
                 doLast {
                     copy {
-                        from(layout.buildDirectory.dir("dist/js/productionExecutable").get().asFile)
-                        into(binaryDestination().get().dir("bin").asFile)
-                    }
-                    copy {
                         from(file(layout.projectDirectory.file("Dockerfile")))
-                        into(binaryDestination().get())
+                        into(binaryRootDirectory())
                     }
                 }
             }

--- a/landing-page/service/Dockerfile
+++ b/landing-page/service/Dockerfile
@@ -23,4 +23,4 @@ ENV SLACK_SERVICE_PATH=${SLACK_SERVICE_PATH}
 ENV SLACK_SERVICE_PUBSUB_PATH=${SLACK_SERVICE_PUBSUB_PATH}
 
 COPY ./default.conf.template /etc/nginx/templates/default.conf.template
-COPY ./bin/ /usr/share/nginx/html
+COPY ./productionExecutable /usr/share/nginx/html

--- a/landing-page/service/build.gradle.kts
+++ b/landing-page/service/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.gchristov.thecodinglove.gradleplugins.binaryDestination
+import com.gchristov.thecodinglove.gradleplugins.binaryRootDirectory
 
 plugins {
     id("frontend-binary-plugin")
@@ -9,7 +9,7 @@ tasks.named("assemble") {
     doLast {
         copy {
             from(file(layout.projectDirectory.file("default.conf.template")))
-            into(binaryDestination().get())
+            into(binaryRootDirectory())
         }
     }
 }

--- a/pulumi/Pulumi.yaml
+++ b/pulumi/Pulumi.yaml
@@ -154,7 +154,7 @@ resources:
           API_URL: https://${domain}/api
           PRELOAD_SEARCH_PUBSUB_TOPIC: preload_search
         platform: linux/amd64
-        context: ../build/services/search-service
+        context: ../search/service/build/dist/js
       imageName: ${artifact-registry.location}-docker.pkg.dev/${artifact-registry.project}/${artifact-registry.repositoryId}/search-service:latest
       registry:
         server: ${artifact-registry.location}-docker.pkg.dev
@@ -235,7 +235,7 @@ resources:
           PORT: "8082"
           API_URL: https://${domain}/api
         platform: linux/amd64
-        context: ../build/services/statistics-service
+        context: ../statistics/service/build/dist/js
       imageName: ${artifact-registry.location}-docker.pkg.dev/${artifact-registry.project}/${artifact-registry.repositoryId}/statistics-service:latest
       registry:
         server: ${artifact-registry.location}-docker.pkg.dev
@@ -314,7 +314,7 @@ resources:
           PORT: "8083"
           API_URL: https://${domain}/api
         platform: linux/amd64
-        context: ../build/services/self-destruct-service
+        context: ../self-destruct/service/build/dist/js
       imageName: ${artifact-registry.location}-docker.pkg.dev/${artifact-registry.project}/${artifact-registry.repositoryId}/self-destruct-service:latest
       registry:
         server: ${artifact-registry.location}-docker.pkg.dev
@@ -396,7 +396,7 @@ resources:
           SLACK_SLASH_COMMAND_PUBSUB_TOPIC: slack_slash_command
           SLACK_INTERACTIVITY_PUBSUB_TOPIC: slack_interactivity
         platform: linux/amd64
-        context: ../build/services/slack-service
+        context: ../slack/service/build/dist/js
       imageName: ${artifact-registry.location}-docker.pkg.dev/${artifact-registry.project}/${artifact-registry.repositoryId}/slack-service:latest
       registry:
         server: ${artifact-registry.location}-docker.pkg.dev
@@ -483,7 +483,7 @@ resources:
           SLACK_SERVICE_PATH: api/slack
           SLACK_SERVICE_PUBSUB_PATH: api/pubsub/slack
         platform: linux/amd64
-        context: ../build/services/landing-page-service
+        context: ../landing-page/service/build/dist/js
       imageName: ${artifact-registry.location}-docker.pkg.dev/${artifact-registry.project}/${artifact-registry.repositoryId}/landing-page-service:latest
       registry:
         server: ${artifact-registry.location}-docker.pkg.dev

--- a/search/service/Dockerfile
+++ b/search/service/Dockerfile
@@ -11,11 +11,11 @@ ENV PRELOAD_SEARCH_PUBSUB_TOPIC=${PRELOAD_SEARCH_PUBSUB_TOPIC}
 WORKDIR /app
 
 # Step 1: Install Node.js dependencies
-COPY /bin/package.json .
+COPY /productionExecutable/package.json .
 RUN npm install --only=production
 
 # Step 2: Copy app files
-COPY /bin/. .
+COPY /productionExecutable .
 
 # Step 3: Run binaries
 FROM npm AS run

--- a/self-destruct/service/Dockerfile
+++ b/self-destruct/service/Dockerfile
@@ -9,11 +9,11 @@ ENV API_URL=${API_URL}
 WORKDIR /app
 
 # Step 1: Install Node.js dependencies
-COPY /bin/package.json .
+COPY /productionExecutable/package.json .
 RUN npm install --only=production
 
 # Step 2: Copy app files
-COPY /bin/. .
+COPY /productionExecutable .
 
 # Step 3: Run binaries
 FROM npm AS run

--- a/slack/service/Dockerfile
+++ b/slack/service/Dockerfile
@@ -15,11 +15,11 @@ ENV SLACK_INTERACTIVITY_PUBSUB_TOPIC=${SLACK_INTERACTIVITY_PUBSUB_TOPIC}
 WORKDIR /app
 
 # Step 1: Install Node.js dependencies
-COPY /bin/package.json .
+COPY /productionExecutable/package.json .
 RUN npm install --only=production
 
 # Step 2: Copy app files
-COPY /bin/. .
+COPY /productionExecutable .
 
 # Step 3: Run binaries
 FROM npm AS run

--- a/statistics/service/Dockerfile
+++ b/statistics/service/Dockerfile
@@ -9,11 +9,11 @@ ENV API_URL=${API_URL}
 WORKDIR /app
 
 # Step 1: Install Node.js dependencies
-COPY /bin/package.json .
+COPY /productionExecutable/package.json .
 RUN npm install --only=production
 
 # Step 2: Copy app files
-COPY /bin/. .
+COPY /productionExecutable .
 
 # Step 3: Run binaries
 FROM npm AS run


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

Previously, all microservices were copied to `build/services`. This isn't really needed as each service has its own `build` directory, so this PR switches to that approach to further decouple things.

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
