### PR TITLE
Npm dependencies are now local to their module

### DIFF
--- a/common/firebase/build.gradle.kts
+++ b/common/firebase/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.gchristov.thecodinglove.gradleplugins.Deps
+
 plugins {
     id("node-module-plugin")
 }
@@ -10,6 +12,11 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(projects.kotlin)
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+                implementation(npm(Deps.Google.firebaseAdmin.name, Deps.Google.firebaseAdmin.version))
             }
         }
     }

--- a/common/network/build.gradle.kts
+++ b/common/network/build.gradle.kts
@@ -19,5 +19,10 @@ kotlin {
                 implementation(Deps.Ktor.logback)
             }
         }
+        val jsMain by getting {
+            dependencies {
+                implementation(npm(Deps.Node.express.name, Deps.Node.express.version))
+            }
+        }
     }
 }

--- a/common/pubsub/build.gradle.kts
+++ b/common/pubsub/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.gchristov.thecodinglove.gradleplugins.Deps
+
 plugins {
     id("node-module-plugin")
 }
@@ -11,6 +13,11 @@ kotlin {
             dependencies {
                 implementation(projects.kotlin)
                 implementation(projects.network)
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+                implementation(npm(Deps.Google.pubSub.name, Deps.Google.pubSub.version))
             }
         }
     }

--- a/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/BinaryPlugin.kt
+++ b/gradle-plugins/src/main/kotlin/com/gchristov/thecodinglove/gradleplugins/BinaryPlugin.kt
@@ -13,16 +13,6 @@ class NodeBinaryPlugin : Plugin<Project> {
                     binaries.library()
                 }
             }
-            extensions.configure(KotlinMultiplatformExtension::class.java) {
-                sourceSets.maybeCreate("jsMain").dependencies {
-                    // Ideally these would be linked from corresponding submodules but that is currently not supported out
-                    // of the box or through the npm-publish plugin and causes "module not found" errors. As a workaround,
-                    // all NPM dependencies will be listed at the top level here.
-                    implementation(npm(Deps.Google.pubSub.name, Deps.Google.pubSub.version))
-                    implementation(npm(Deps.Node.express.name, Deps.Node.express.version))
-                    implementation(npm(Deps.Google.firebaseAdmin.name, Deps.Google.firebaseAdmin.version))
-                }
-            }
             // Copy the output binaries to their final destination
             tasks.named("assemble") {
                 doLast {

--- a/search/adapter/build.gradle.kts
+++ b/search/adapter/build.gradle.kts
@@ -23,5 +23,10 @@ kotlin {
                 implementation(projects.testFixtures)
             }
         }
+        val jsMain by getting {
+            dependencies {
+                implementation(npm(Deps.Node.htmlParser.name, Deps.Node.htmlParser.version))
+            }
+        }
     }
 }

--- a/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/JavascriptSearchAdapter.kt
+++ b/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/JavascriptSearchAdapter.kt
@@ -1,7 +1,7 @@
 package com.gchristov.thecodinglove.search.adapter
 
-import com.gchristov.thecodinglove.htmlparsedata.usecase.NodeParseHtmlPostsUseCase
-import com.gchristov.thecodinglove.htmlparsedata.usecase.NodeParseHtmlTotalPostsUseCase
+import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.NodeParseHtmlPostsUseCase
+import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.NodeParseHtmlTotalPostsUseCase
 import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.ParseHtmlPostsUseCase
 import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.ParseHtmlTotalPostsUseCase
 import kotlinx.coroutines.Dispatchers

--- a/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlPostsUseCase.kt
+++ b/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlPostsUseCase.kt
@@ -1,9 +1,8 @@
-package com.gchristov.thecodinglove.htmlparsedata.usecase
+package com.gchristov.thecodinglove.search.adapter.htmlparser.usecase
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.common.kotlin.requireModule
 import com.gchristov.thecodinglove.search.adapter.htmlparser.model.HtmlPost
-import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.ParseHtmlPostsUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 

--- a/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlTotalPostsUseCase.kt
+++ b/search/adapter/src/jsMain/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlTotalPostsUseCase.kt
@@ -1,8 +1,7 @@
-package com.gchristov.thecodinglove.htmlparsedata.usecase
+package com.gchristov.thecodinglove.search.adapter.htmlparser.usecase
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.common.kotlin.requireModule
-import com.gchristov.thecodinglove.search.adapter.htmlparser.usecase.ParseHtmlTotalPostsUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
 

--- a/search/adapter/src/jsTest/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlPostsUseCaseTest.kt
+++ b/search/adapter/src/jsTest/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlPostsUseCaseTest.kt
@@ -2,7 +2,6 @@ package com.gchristov.thecodinglove.search.adapter.htmlparser.usecase
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.common.test.FakeCoroutineDispatcher
-import com.gchristov.thecodinglove.htmlparsedata.usecase.NodeParseHtmlPostsUseCase
 import com.gchristov.thecodinglove.search.adapter.htmlparser.model.HtmlPost
 import com.gchristov.thecodinglove.search.testfixtures.HtmlCreator
 import kotlinx.coroutines.test.runTest

--- a/search/adapter/src/jsTest/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlTotalPostsUseCaseTest.kt
+++ b/search/adapter/src/jsTest/kotlin/com/gchristov/thecodinglove/search/adapter/htmlparser/usecase/NodeParseHtmlTotalPostsUseCaseTest.kt
@@ -2,7 +2,6 @@ package com.gchristov.thecodinglove.search.adapter.htmlparser.usecase
 
 import arrow.core.Either
 import com.gchristov.thecodinglove.common.test.FakeCoroutineDispatcher
-import com.gchristov.thecodinglove.htmlparsedata.usecase.NodeParseHtmlTotalPostsUseCase
 import com.gchristov.thecodinglove.search.testfixtures.HtmlCreator
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test

--- a/search/service/build.gradle.kts
+++ b/search/service/build.gradle.kts
@@ -17,13 +17,5 @@ kotlin {
                 implementation(projects.adapter)
             }
         }
-        val jsMain by getting {
-            dependencies {
-                // Ideally these would be linked from corresponding submodules but that is currently not supported out
-                // of the box or through the npm-publish plugin and causes "module not found" errors. As a workaround,
-                // all NPM dependencies will be listed at the top level here.
-                implementation(npm(Deps.Node.htmlParser.name, Deps.Node.htmlParser.version))
-            }
-        }
     }
 }


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This has been fixed apparently, so now the npm dependencies can be at their correct locations.

## How is this change tested?

Manually and with CI.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
