### PR TITLE
Fix build and stuck self-destruct message

### DIFF
--- a/.github/workflows/common-check.yml
+++ b/.github/workflows/common-check.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   common-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-common-check-build
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
             common/infra
 
   common-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-common-check-test
       cancel-in-progress: true

--- a/.github/workflows/common-deploy.yml
+++ b/.github/workflows/common-deploy.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   common-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-common-deploy-build
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
             common/infra
 
   common-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-common-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/landing-page-web-check.yml
+++ b/.github/workflows/landing-page-web-check.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   landing-page-web-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-landing-page-web-check-build
       cancel-in-progress: true
@@ -59,7 +59,7 @@ jobs:
             landing-page-web/infra
 
   landing-page-web-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-landing-page-web-check-test
       cancel-in-progress: true

--- a/.github/workflows/landing-page-web-deploy.yml
+++ b/.github/workflows/landing-page-web-deploy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   landing-page-web-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-landing-page-web-deploy-build
       cancel-in-progress: true
@@ -55,7 +55,7 @@ jobs:
             landing-page-web/infra
 
   landing-page-web-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-landing-page-web-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/proxy-web-check.yml
+++ b/.github/workflows/proxy-web-check.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   proxy-web-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-proxy-web-check-build
       cancel-in-progress: true
@@ -59,7 +59,7 @@ jobs:
             proxy-web/infra
 
   proxy-web-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-proxy-web-check-test
       cancel-in-progress: true

--- a/.github/workflows/proxy-web-deploy.yml
+++ b/.github/workflows/proxy-web-deploy.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   proxy-web-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-proxy-web-deploy-build
       cancel-in-progress: true
@@ -55,7 +55,7 @@ jobs:
             proxy-web/infra
 
   proxy-web-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-proxy-web-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/search-check.yml
+++ b/.github/workflows/search-check.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   search-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-search-check-build
       cancel-in-progress: true
@@ -67,7 +67,7 @@ jobs:
             search/infra
 
   search-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-search-check-test
       cancel-in-progress: true

--- a/.github/workflows/search-deploy.yml
+++ b/.github/workflows/search-deploy.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   search-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-search-deploy-build
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
             search/infra
 
   search-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-search-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/self-destruct-check.yml
+++ b/.github/workflows/self-destruct-check.yml
@@ -12,6 +12,8 @@ env:
   GCP_SA_KEY_INFRA: ${{ secrets.GCP_SA_KEY_INFRA }}
   GCP_SA_KEY_APP: ${{ secrets.GCP_SA_KEY_APP }}
   MONITORING_SLACK_URL: ${{ secrets.MONITORING_SLACK_URL }}
+  GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+  GOOGLE_ANALYTICS_API_SECRET: ${{ secrets.GOOGLE_ANALYTICS_API_SECRET }}
 
 jobs:
   self-destruct-check-build:
@@ -34,6 +36,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./self-destruct/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Build project
         run: |
           set -o pipefail && 
@@ -82,6 +86,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./self-destruct/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Test
         run: |
           set -o pipefail && 

--- a/.github/workflows/self-destruct-check.yml
+++ b/.github/workflows/self-destruct-check.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   self-destruct-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-self-destruct-check-build
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
             self-destruct/infra
 
   self-destruct-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-self-destruct-check-test
       cancel-in-progress: true

--- a/.github/workflows/self-destruct-deploy.yml
+++ b/.github/workflows/self-destruct-deploy.yml
@@ -12,6 +12,8 @@ env:
   GCP_SA_KEY_INFRA: ${{ secrets.GCP_SA_KEY_INFRA }}
   GCP_SA_KEY_APP: ${{ secrets.GCP_SA_KEY_APP }}
   MONITORING_SLACK_URL: ${{ secrets.MONITORING_SLACK_URL }}
+  GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+  GOOGLE_ANALYTICS_API_SECRET: ${{ secrets.GOOGLE_ANALYTICS_API_SECRET }}
 
 jobs:
   self-destruct-deploy-build:
@@ -34,6 +36,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./self-destruct/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Build project
         run: |
           set -o pipefail && 
@@ -78,6 +82,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./self-destruct/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Test
         run: |
           set -o pipefail && 

--- a/.github/workflows/self-destruct-deploy.yml
+++ b/.github/workflows/self-destruct-deploy.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   self-destruct-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-self-destruct-deploy-build
       cancel-in-progress: true
@@ -59,7 +59,7 @@ jobs:
             self-destruct/infra
 
   self-destruct-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-self-destruct-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/slack-check.yml
+++ b/.github/workflows/slack-check.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   slack-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-check-build
       cancel-in-progress: true
@@ -73,7 +73,7 @@ jobs:
             slack/infra
 
   slack-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-check-test
       cancel-in-progress: true

--- a/.github/workflows/slack-deploy.yml
+++ b/.github/workflows/slack-deploy.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   slack-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-deploy-build
       cancel-in-progress: true
@@ -69,7 +69,7 @@ jobs:
             slack/infra
 
   slack-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/slack-web-check.yml
+++ b/.github/workflows/slack-web-check.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   slack-web-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-web-check-build
       cancel-in-progress: true
@@ -69,7 +69,7 @@ jobs:
             slack-web/infra
 
   slack-web-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-web-check-test
       cancel-in-progress: true

--- a/.github/workflows/slack-web-deploy.yml
+++ b/.github/workflows/slack-web-deploy.yml
@@ -18,7 +18,7 @@ env:
 
 jobs:
   slack-web-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-web-deploy-build
       cancel-in-progress: true
@@ -65,7 +65,7 @@ jobs:
             slack-web/infra
 
   slack-web-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-slack-web-deploy-test
       cancel-in-progress: true

--- a/.github/workflows/statistics-check.yml
+++ b/.github/workflows/statistics-check.yml
@@ -12,6 +12,8 @@ env:
   GCP_SA_KEY_INFRA: ${{ secrets.GCP_SA_KEY_INFRA }}
   GCP_SA_KEY_APP: ${{ secrets.GCP_SA_KEY_APP }}
   MONITORING_SLACK_URL: ${{ secrets.MONITORING_SLACK_URL }}
+  GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+  GOOGLE_ANALYTICS_API_SECRET: ${{ secrets.GOOGLE_ANALYTICS_API_SECRET }}
 
 jobs:
   statistics-check-build:
@@ -34,6 +36,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./statistics/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Build project
         run: |
           set -o pipefail && 
@@ -82,6 +86,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./statistics/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Test
         run: |
           set -o pipefail && 

--- a/.github/workflows/statistics-check.yml
+++ b/.github/workflows/statistics-check.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   statistics-check-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-statistics-check-build
       cancel-in-progress: true
@@ -63,7 +63,7 @@ jobs:
             statistics/infra
 
   statistics-check-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-statistics-check-test
       cancel-in-progress: true

--- a/.github/workflows/statistics-deploy.yml
+++ b/.github/workflows/statistics-deploy.yml
@@ -12,6 +12,8 @@ env:
   GCP_SA_KEY_INFRA: ${{ secrets.GCP_SA_KEY_INFRA }}
   GCP_SA_KEY_APP: ${{ secrets.GCP_SA_KEY_APP }}
   MONITORING_SLACK_URL: ${{ secrets.MONITORING_SLACK_URL }}
+  GOOGLE_ANALYTICS_MEASUREMENT_ID: ${{ secrets.GOOGLE_ANALYTICS_MEASUREMENT_ID }}
+  GOOGLE_ANALYTICS_API_SECRET: ${{ secrets.GOOGLE_ANALYTICS_API_SECRET }}
 
 jobs:
   statistics-deploy-build:
@@ -34,6 +36,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./statistics/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Build project
         run: |
           set -o pipefail && 
@@ -78,6 +82,8 @@ jobs:
           echo "$GCP_SA_KEY_INFRA" >> ./statistics/infra/credentials-gcp-infra.json
           echo "$GCP_SA_KEY_APP" >> ./credentials-gcp-app.json
           echo MONITORING_SLACK_URL="$MONITORING_SLACK_URL" >> ./common/monitoring/secrets.properties
+          echo GOOGLE_ANALYTICS_MEASUREMENT_ID="$GOOGLE_ANALYTICS_MEASUREMENT_ID" >> ./common/analytics/secrets.properties
+          echo GOOGLE_ANALYTICS_API_SECRET="$GOOGLE_ANALYTICS_API_SECRET" >> ./common/analytics/secrets.properties
       - name: Test
         run: |
           set -o pipefail && 

--- a/.github/workflows/statistics-deploy.yml
+++ b/.github/workflows/statistics-deploy.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   statistics-deploy-build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-statistics-deploy-build
       cancel-in-progress: true
@@ -59,7 +59,7 @@ jobs:
             statistics/infra
 
   statistics-deploy-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.ref }}-statistics-deploy-test
       cancel-in-progress: true

--- a/common/infra/Pulumi.yaml
+++ b/common/infra/Pulumi.yaml
@@ -15,6 +15,7 @@ resources:
       disableDependentServices: true
       service: cloudresourcemanager.googleapis.com
     options:
+      version: 8.6.0
       protect: true
   # Enables the Artifact Registry API. Needed for Docker.
   artifact-registry-api:
@@ -23,6 +24,7 @@ resources:
       disableDependentServices: true
       service: artifactregistry.googleapis.com
     options:
+      version: 8.6.0
       protect: true
   # Enables Firebase API. Needed for Firestore.
   firebase-api:
@@ -31,6 +33,7 @@ resources:
       disableDependentServices: true
       service: firebase.googleapis.com
     options:
+      version: 8.6.0
       protect: true
   # Enables the Firestore API.
   firestore-api:
@@ -39,6 +42,7 @@ resources:
       disableDependentServices: true
       service: firestore.googleapis.com
     options:
+      version: 8.6.0
       protect: true
       dependsOn:
         - ${cloud-resource-manager-api}
@@ -49,6 +53,7 @@ resources:
       disableDependentServices: true
       service: run.googleapis.com
     options:
+      version: 8.6.0
       protect: true
   # Enables the PubSub API.
   pubsub-api:
@@ -57,6 +62,7 @@ resources:
       disableDependentServices: true
       service: pubsub.googleapis.com
     options:
+      version: 8.6.0
       protect: true
 
   ########################################
@@ -71,6 +77,7 @@ resources:
       location: europe-west1
       repositoryId: thecodinglove
     options:
+      version: 8.6.0
       protect: true
       dependsOn:
         - ${artifact-registry-api}
@@ -83,6 +90,7 @@ resources:
   firebase:
     type: gcp:firebase:Project
     options:
+      version: 8.6.0
       protect: true
       dependsOn:
         - ${firebase-api}
@@ -98,6 +106,7 @@ resources:
       name: (default)
       type: FIRESTORE_NATIVE
     options:
+      version: 8.6.0
       protect: true
       dependsOn:
         - ${firestore-api}
@@ -121,6 +130,7 @@ resources:
               }
             name: firestore.rules
     options:
+      version: 8.6.0
       protect: true
       dependsOn:
         - ${firestore}
@@ -132,4 +142,5 @@ resources:
       name: cloud.firestore
       rulesetName: projects/${firestore-rules.project}/rulesets/${firestore-rules.name}
     options:
+      version: 8.6.0
       protect: true

--- a/landing-page-web/infra/Pulumi.yaml
+++ b/landing-page-web/infra/Pulumi.yaml
@@ -39,8 +39,8 @@ resources:
         containers:
           - image: ${landing-page-web-service-binary.repoDigest}
             ports:
-              - containerPort: 80
-                name: http1
+              containerPort: 80
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -61,6 +61,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   landing-page-web-service-policy:
@@ -80,6 +81,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
 outputs:

--- a/proxy-web/infra/Pulumi.yaml
+++ b/proxy-web/infra/Pulumi.yaml
@@ -83,8 +83,8 @@ resources:
         containers:
           - image: ${proxy-web-service-binary.repoDigest}
             ports:
-              - containerPort: 80
-                name: http1
+              containerPort: 80
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -105,6 +105,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   proxy-web-service-policy:
@@ -124,6 +125,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service domain mapping.
   proxy-web-service-domain-mapping:
@@ -136,4 +138,5 @@ resources:
       spec:
         routeName: proxy-web-service
     options:
+      version: 8.6.0
       protect: true

--- a/search/infra/Pulumi.yaml
+++ b/search/infra/Pulumi.yaml
@@ -44,8 +44,8 @@ resources:
         containers:
           - image: ${search-service-binary.repoDigest}
             ports:
-              - containerPort: 8081
-                name: http1
+              containerPort: 8081
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -66,6 +66,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   search-service-policy:
@@ -85,6 +86,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
   ########################################
@@ -97,6 +99,7 @@ resources:
     properties:
       name: preload_search
     options:
+      version: 8.6.0
       protect: true
   # Manages the preload search PubSub subscription.
   pubsub-subscription-preload-search:
@@ -114,6 +117,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-preload-search.name}
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev preload search PubSub topic.
   pubsub-topic-preload-search-dev:
@@ -121,6 +125,7 @@ resources:
     properties:
       name: preload_search_dev
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev preload search PubSub subscription.
   pubsub-subscription-preload-search-dev:
@@ -139,6 +144,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-preload-search-dev.name}
     options:
+      version: 8.6.0
       protect: true
 
 outputs:

--- a/self-destruct/infra/Pulumi.yaml
+++ b/self-destruct/infra/Pulumi.yaml
@@ -43,8 +43,8 @@ resources:
         containers:
           - image: ${self-destruct-service-binary.repoDigest}
             ports:
-              - containerPort: 8083
-                name: http1
+              containerPort: 8083
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -65,6 +65,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   self-destruct-service-policy:
@@ -84,6 +85,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
   ########################################
@@ -108,6 +110,7 @@ resources:
         minBackoffDuration: 10s
         maxDoublings: 5
     options:
+      version: 8.6.0
       protect: true
 
 outputs:

--- a/slack-web/infra/Pulumi.yaml
+++ b/slack-web/infra/Pulumi.yaml
@@ -41,8 +41,8 @@ resources:
         containers:
           - image: ${slack-web-service-binary.repoDigest}
             ports:
-              - containerPort: 8086
-                name: http1
+              containerPort: 8086
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -63,6 +63,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   slack-web-service-policy:
@@ -82,6 +83,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
 outputs:

--- a/slack/infra/Pulumi.yaml
+++ b/slack/infra/Pulumi.yaml
@@ -46,8 +46,8 @@ resources:
         containers:
           - image: ${slack-service-binary.repoDigest}
             ports:
-              - containerPort: 8084
-                name: http1
+              containerPort: 8084
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -68,6 +68,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   slack-service-policy:
@@ -87,6 +88,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
   ########################################
@@ -99,6 +101,7 @@ resources:
     properties:
       name: slack_interactivity
     options:
+      version: 8.6.0
       protect: true
   # Manages the Slack interactivity PubSub subscription.
   pubsub-subscription-slack-interactivity:
@@ -116,6 +119,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-slack-interactivity.name}
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev Slack interactivity PubSub topic.
   pubsub-topic-slack-interactivity-dev:
@@ -123,6 +127,7 @@ resources:
     properties:
       name: slack_interactivity_dev
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev Slack interactivity PubSub subscription.
   pubsub-subscription-slack-interactivity-dev:
@@ -141,6 +146,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-slack-interactivity-dev.name}
     options:
+      version: 8.6.0
       protect: true
   # Manages the Slack slash command PubSub topic.
   pubsub-topic-slack-slash-command:
@@ -148,6 +154,7 @@ resources:
     properties:
       name: slack_slash_command
     options:
+      version: 8.6.0
       protect: true
   # Manages the Slack slash command PubSub subscription.
   pubsub-subscription-slack-slash-command:
@@ -165,6 +172,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-slack-slash-command.name}
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev Slack slash command PubSub topic.
   pubsub-topic-slack-slash-command-dev:
@@ -172,6 +180,7 @@ resources:
     properties:
       name: slack_slash_command_dev
     options:
+      version: 8.6.0
       protect: true
   # Manages the dev Slack slash command PubSub subscription.
   pubsub-subscription-slack-slash-command-dev:
@@ -190,6 +199,7 @@ resources:
         minimumBackoff: 10s
       topic: ${pubsub-topic-slack-slash-command-dev.name}
     options:
+      version: 8.6.0
       protect: true
 
 outputs:

--- a/statistics/infra/Pulumi.yaml
+++ b/statistics/infra/Pulumi.yaml
@@ -43,8 +43,8 @@ resources:
         containers:
           - image: ${statistics-service-binary.repoDigest}
             ports:
-              - containerPort: 8082
-                name: http1
+              containerPort: 8082
+              name: http1
             resources:
               cpuIdle: true
               limits:
@@ -65,6 +65,7 @@ resources:
         - percent: 100
           type: TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST
     options:
+      version: 8.6.0
       protect: true
   # Manages the Cloud Run service policy.
   statistics-service-policy:
@@ -84,6 +85,7 @@ resources:
           ]
         }
     options:
+      version: 8.6.0
       protect: true
 
 outputs:


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR 
- fixes a stuck self-destruct message which cannot be deleted because Slack says it doesn't exist. Instead, we now check for this error and assume the message is already deleted, so we can remove it from our queue.
- fixes `/usr/local/bin/pulumi-language-yaml: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.32 not found (required by /usr/local/bin/pulumi-language-yaml)` by updating to `ubuntu-24.04`
- fixes `ports: Cannot assign 'List<***containerPort: number***>' to 'gcp:cloudrunv2/ServiceTemplateContainerPorts:ServiceTemplateContainerPorts'` by fixing the GCP provider version and applying the breaking change that was introduced in version [8.0.0](https://github.com/pulumi/pulumi-gcp/releases/tag/v8.0.0)

## How is this change tested?

Manually.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
