### PR TITLE
Publish build scans from root project

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    // Allows publishing build scans when common tasks run from the project root, eg jsTest
+    id("com.gradle.develocity") version("3.18.1")
+}
+
 rootProject.name = "thecodinglove-kotlinjs"
 
 // Add or remove projects here from the common build. Alternatively, each project can be opened in isolation.
@@ -10,3 +15,11 @@ includeBuild("self-destruct")
 includeBuild("slack")
 includeBuild("slack-web")
 includeBuild("statistics")
+
+develocity {
+    buildScan {
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+        publishing.onlyIf { true }
+    }
+}


### PR DESCRIPTION
<!-- Feel free to delete irrelevant sections or add new ones as you see fit. -->

## What does this pull request change?

This PR updates the root project config to allow publishing build scans. This allows the shared unit test job to publish a scan.

## How is this change tested?

Manually and with existing checks.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)
