### PR TITLE
[TAS-384] Decouple Slack send-message flow from authentication checking

### DIFF
--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
@@ -157,6 +157,7 @@ interface SlackAdapterComponent {
     fun provideSlackInteractivityPubSubHandler(
         jsonSerializer: JsonSerializer.Default,
         log: Logger,
+        slackEnsureAuthenticatedUseCase: SlackEnsureAuthenticatedUseCase,
         slackSendSearchUseCase: SlackSendSearchUseCase,
         slackShuffleSearchUseCase: SlackShuffleSearchUseCase,
         slackCancelSearchUseCase: SlackCancelSearchUseCase,
@@ -169,9 +170,14 @@ interface SlackAdapterComponent {
         jsonSerializer = jsonSerializer,
         log = log,
         eventHandlers = listOf(
-            SlackSendInteractivityPubSubHandler(slackSendSearchUseCase, analytics),
+            SlackSendInteractivityPubSubHandler(
+                slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
+                slackSendSearchUseCase = slackSendSearchUseCase,
+                analytics = analytics,
+            ),
             SlackSelfDestructInteractivityPubSubHandler(
                 jsonSerializer = jsonSerializer,
+                slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 pubSubPublisher = pubSubPublisher,
                 slackConfig = slackConfig,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
@@ -12,6 +12,7 @@ import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackInteractivity
 import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackSelfDestructMessageEvent
 import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
+import com.gchristov.thecodinglove.slack.domain.usecase.SlackEnsureAuthenticatedUseCase
 import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.DeserializationStrategy
@@ -21,6 +22,7 @@ import kotlin.time.Instant
 
 internal class SlackSelfDestructInteractivityPubSubHandler(
     override val jsonSerializer: JsonSerializer,
+    private val slackEnsureAuthenticatedUseCase: SlackEnsureAuthenticatedUseCase,
     private val slackSendSearchUseCase: SlackSendSearchUseCase,
     private val pubSubPublisher: PubSubPublisher,
     private val slackConfig: SlackConfig,
@@ -41,6 +43,17 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
             name = "slack_interactivity_self_destruct",
             params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
         )
+        val authResult = slackEnsureAuthenticatedUseCase(
+            SlackEnsureAuthenticatedUseCase.Dto(
+                userId = event.user.id,
+                teamId = event.team.id,
+                channelId = event.channel.id,
+                responseUrl = event.responseUrl,
+                searchSessionId = action.value,
+                selfDestructMinutes = 5,
+            )
+        ).getOrElse { return Either.Left(it) }
+        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) return Either.Right(Unit)
         val selfDestructMessage = slackSendSearchUseCase(
             SlackSendSearchUseCase.Dto(
                 userId = event.user.id,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
@@ -43,6 +43,8 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
             name = "slack_interactivity_self_destruct",
             params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
         )
+        // Check auth before sending - if the user isn't authenticated, a prompt is sent instead and
+        // there's nothing left to do here.
         val authResult = slackEnsureAuthenticatedUseCase(
             SlackEnsureAuthenticatedUseCase.Dto(
                 userId = event.user.id,
@@ -53,7 +55,10 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
                 selfDestructMinutes = 5,
             )
         ).getOrElse { return Either.Left(it) }
-        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) return Either.Right(Unit)
+        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
+            return Either.Right(Unit)
+        }
+
         val selfDestructMessage = slackSendSearchUseCase(
             SlackSendSearchUseCase.Dto(
                 userId = event.user.id,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
@@ -1,6 +1,7 @@
 package com.gchristov.thecodinglove.slack.adapter.pubsub
 
 import arrow.core.Either
+import arrow.core.getOrElse
 import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.common.analytics.Analytics
 import com.gchristov.thecodinglove.common.kotlin.JsonSerializer
@@ -8,11 +9,13 @@ import com.gchristov.thecodinglove.common.pubsub.PubSubDecoder
 import com.gchristov.thecodinglove.common.pubsub.PubSubHandler
 import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackInteractivityReceivedEvent
 import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
+import com.gchristov.thecodinglove.slack.domain.usecase.SlackEnsureAuthenticatedUseCase
 import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.DeserializationStrategy
 
 internal class SlackSendInteractivityPubSubHandler(
+    private val slackEnsureAuthenticatedUseCase: SlackEnsureAuthenticatedUseCase,
     private val slackSendSearchUseCase: SlackSendSearchUseCase,
     private val analytics: Analytics,
 ) : PubSubHandler<SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage> {
@@ -31,6 +34,17 @@ internal class SlackSendInteractivityPubSubHandler(
             name = "slack_interactivity_send",
             params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
         )
+        val authResult = slackEnsureAuthenticatedUseCase(
+            SlackEnsureAuthenticatedUseCase.Dto(
+                userId = event.user.id,
+                teamId = event.team.id,
+                channelId = event.channel.id,
+                responseUrl = event.responseUrl,
+                searchSessionId = action.value,
+                selfDestructMinutes = null,
+            )
+        ).getOrElse { return Either.Left(it) }
+        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) return Either.Right(Unit)
         // This flow never self-destructs (selfDestructMinutes = null), so there's never a message to
         // schedule - discard the returned SlackSelfDestructMessage? to satisfy PubSubHandler's Unit contract.
         return slackSendSearchUseCase(

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
@@ -34,6 +34,8 @@ internal class SlackSendInteractivityPubSubHandler(
             name = "slack_interactivity_send",
             params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
         )
+        // Check auth before sending - if the user isn't authenticated, a prompt is sent instead and
+        // there's nothing left to do here.
         val authResult = slackEnsureAuthenticatedUseCase(
             SlackEnsureAuthenticatedUseCase.Dto(
                 userId = event.user.id,
@@ -44,7 +46,10 @@ internal class SlackSendInteractivityPubSubHandler(
                 selfDestructMinutes = null,
             )
         ).getOrElse { return Either.Left(it) }
-        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) return Either.Right(Unit)
+        if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
+            return Either.Right(Unit)
+        }
+
         // This flow never self-destructs (selfDestructMinutes = null), so there's never a message to
         // schedule - discard the returned SlackSelfDestructMessage? to satisfy PubSubHandler's Unit contract.
         return slackSendSearchUseCase(

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
@@ -13,6 +13,7 @@ import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackInteractivity
 import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackSelfDestructMessage
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackCancelSearchUseCase
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackEnsureAuthenticatedUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSendSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackShuffleSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.SlackConfigCreator
@@ -85,6 +86,7 @@ class SlackInteractivityPubSubHandlerTest {
         sendResult: Either<Throwable, SlackSelfDestructMessage?> = Either.Right(null),
         testBlock: suspend (SlackInteractivityPubSubHandler, FakeSlackSendSearchUseCase, FakeSlackShuffleSearchUseCase) -> Unit,
     ): TestResult = runTest {
+        val ensureAuthUseCase = FakeSlackEnsureAuthenticatedUseCase()
         val sendUseCase = FakeSlackSendSearchUseCase(invocationResult = sendResult)
         val shuffleUseCase = FakeSlackShuffleSearchUseCase()
         val cancelUseCase = FakeSlackCancelSearchUseCase()
@@ -94,9 +96,14 @@ class SlackInteractivityPubSubHandlerTest {
             jsonSerializer = JsonSerializer.Default,
             log = FakeLogger,
             eventHandlers = listOf(
-                SlackSendInteractivityPubSubHandler(sendUseCase, analytics),
+                SlackSendInteractivityPubSubHandler(
+                    slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
+                    slackSendSearchUseCase = sendUseCase,
+                    analytics = analytics,
+                ),
                 SlackSelfDestructInteractivityPubSubHandler(
                     jsonSerializer = JsonSerializer.Default,
+                    slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
                     slackSendSearchUseCase = sendUseCase,
                     pubSubPublisher = FakePubSubPublisher(),
                     slackConfig = SlackConfigCreator.slackConfig(),

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
@@ -6,6 +6,8 @@ import com.gchristov.thecodinglove.common.kotlin.JsonSerializer
 import com.gchristov.thecodinglove.common.pubsubtestfixtures.FakePubSubPublisher
 import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackSelfDestructMessage
+import com.gchristov.thecodinglove.slack.domain.usecase.SlackEnsureAuthenticatedUseCase
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackEnsureAuthenticatedUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSendSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.SlackConfigCreator
 import com.gchristov.thecodinglove.slack.testfixtures.SlackSelfDestructMessageCreator
@@ -17,26 +19,28 @@ import kotlin.test.assertTrue
 
 class SlackSelfDestructInteractivityPubSubHandlerTest {
     @Test
-    fun handleSelfDestruct5MinInvokesSendUseCaseWith5Minutes(): TestResult = runBlockingTest { handler, sendUseCase, _ ->
+    fun handleSelfDestruct5MinInvokesSendUseCaseWith5Minutes(): TestResult = runBlockingTest { handler, ensureAuthUseCase, sendUseCase, _ ->
         val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
+        ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
         sendUseCase.assertSelfDestructMinutes(5)
     }
 
     @Test
-    fun handleOtherActionSkips(): TestResult = runBlockingTest { handler, sendUseCase, _ ->
+    fun handleOtherActionSkips(): TestResult = runBlockingTest { handler, ensureAuthUseCase, sendUseCase, _ ->
         val payload = interactivityMessage(action = SlackActionName.SHUFFLE).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
+        ensureAuthUseCase.assertNotInvoked()
         sendUseCase.assertNotInvoked()
     }
 
     @Test
     fun handleSelfDestructErrorReturnsLeft(): TestResult = runBlockingTest(
         sendResult = Either.Left(Throwable("Send failed"))
-    ) { handler, _, _ ->
+    ) { handler, _, _, _ ->
         val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertFalse { result.isRight() }
@@ -45,7 +49,7 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
     @Test
     fun handleSelfDestructMessageSentSchedulesSelfDestruct(): TestResult = runBlockingTest(
         sendResult = Either.Right(SlackSelfDestructMessageCreator.pastMessage()),
-    ) { handler, _, pubSubPublisher ->
+    ) { handler, _, _, pubSubPublisher ->
         val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
@@ -55,27 +59,58 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
     @Test
     fun handleNoSelfDestructMessageDoesNotSchedule(): TestResult = runBlockingTest(
         sendResult = Either.Right(null),
-    ) { handler, _, pubSubPublisher ->
+    ) { handler, _, _, pubSubPublisher ->
         val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
         pubSubPublisher.assertNotInvoked()
     }
 
+    @Test
+    fun handleAuthenticationPromptSentSkipsSendUseCaseAndDoesNotSchedule(): TestResult = runBlockingTest(
+        ensureAuthResult = Either.Right(SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent),
+    ) { handler, _, sendUseCase, pubSubPublisher ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        sendUseCase.assertNotInvoked()
+        pubSubPublisher.assertNotInvoked()
+    }
+
+    @Test
+    fun handleEnsureAuthenticatedErrorReturnsLeft(): TestResult = runBlockingTest(
+        ensureAuthResult = Either.Left(Throwable("Ensure auth failed")),
+    ) { handler, _, sendUseCase, pubSubPublisher ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+        sendUseCase.assertNotInvoked()
+        pubSubPublisher.assertNotInvoked()
+    }
+
     private fun runBlockingTest(
+        ensureAuthResult: Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
+            Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated),
         sendResult: Either<Throwable, SlackSelfDestructMessage?> = Either.Right(null),
-        testBlock: suspend (SlackSelfDestructInteractivityPubSubHandler, FakeSlackSendSearchUseCase, FakePubSubPublisher) -> Unit,
+        testBlock: suspend (
+            SlackSelfDestructInteractivityPubSubHandler,
+            FakeSlackEnsureAuthenticatedUseCase,
+            FakeSlackSendSearchUseCase,
+            FakePubSubPublisher,
+        ) -> Unit,
     ): TestResult = runTest {
+        val ensureAuthUseCase = FakeSlackEnsureAuthenticatedUseCase(invocationResult = ensureAuthResult)
         val sendUseCase = FakeSlackSendSearchUseCase(invocationResult = sendResult)
         val pubSubPublisher = FakePubSubPublisher()
         val handler = SlackSelfDestructInteractivityPubSubHandler(
             jsonSerializer = JsonSerializer.Default,
+            slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
             slackSendSearchUseCase = sendUseCase,
             pubSubPublisher = pubSubPublisher,
             slackConfig = SlackConfigCreator.slackConfig(selfDestructMessagePubSubTopic = TestSelfDestructTopic),
             analytics = FakeAnalytics(),
         )
-        testBlock(handler, sendUseCase, pubSubPublisher)
+        testBlock(handler, ensureAuthUseCase, sendUseCase, pubSubPublisher)
     }
 }
 

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
@@ -4,6 +4,8 @@ import arrow.core.Either
 import com.gchristov.thecodinglove.common.analyticstestfixtures.FakeAnalytics
 import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackSelfDestructMessage
+import com.gchristov.thecodinglove.slack.domain.usecase.SlackEnsureAuthenticatedUseCase
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackEnsureAuthenticatedUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSendSearchUseCase
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -17,6 +19,7 @@ class SlackSendInteractivityPubSubHandlerTest {
         val payload = interactivityMessage(action = SlackActionName.SEND).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
+        ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
         sendUseCase.assertSelfDestructMinutes(null)
     }
@@ -26,6 +29,7 @@ class SlackSendInteractivityPubSubHandlerTest {
         val payload = interactivityMessage(action = SlackActionName.SHUFFLE).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
+        ensureAuthUseCase.assertNotInvoked()
         sendUseCase.assertNotInvoked()
     }
 
@@ -38,14 +42,39 @@ class SlackSendInteractivityPubSubHandlerTest {
         assertFalse { result.isRight() }
     }
 
+    @Test
+    fun handleAuthenticationPromptSentSkipsSendUseCase(): TestResult = runBlockingTest(
+        ensureAuthResult = Either.Right(SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent),
+    ) { handler ->
+        val payload = interactivityMessage(action = SlackActionName.SEND).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        sendUseCase.assertNotInvoked()
+    }
+
+    @Test
+    fun handleEnsureAuthenticatedErrorReturnsLeft(): TestResult = runBlockingTest(
+        ensureAuthResult = Either.Left(Throwable("Ensure auth failed")),
+    ) { handler ->
+        val payload = interactivityMessage(action = SlackActionName.SEND).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+        sendUseCase.assertNotInvoked()
+    }
+
+    private lateinit var ensureAuthUseCase: FakeSlackEnsureAuthenticatedUseCase
     private lateinit var sendUseCase: FakeSlackSendSearchUseCase
 
     private fun runBlockingTest(
+        ensureAuthResult: Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
+            Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated),
         sendResult: Either<Throwable, SlackSelfDestructMessage?> = Either.Right(null),
         testBlock: suspend (SlackSendInteractivityPubSubHandler) -> Unit,
     ): TestResult = runTest {
+        ensureAuthUseCase = FakeSlackEnsureAuthenticatedUseCase(invocationResult = ensureAuthResult)
         sendUseCase = FakeSlackSendSearchUseCase(invocationResult = sendResult)
         val handler = SlackSendInteractivityPubSubHandler(
+            slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
             slackSendSearchUseCase = sendUseCase,
             analytics = FakeAnalytics(),
         )

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackDomainComponent.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackDomainComponent.kt
@@ -114,14 +114,12 @@ interface SlackDomainComponent {
         log: Logger,
         slackSearchRepository: SlackSearchRepository,
         slackRepository: SlackRepository,
-        slackConfig: SlackConfig,
         slackMessageFactory: SlackMessageFactory,
     ): SlackSendSearchUseCase = RealSlackSendSearchUseCase(
         dispatcher = Dispatchers.Default,
         log = log,
         slackSearchRepository = slackSearchRepository,
         slackRepository = slackRepository,
-        slackConfig = slackConfig,
         slackMessageFactory = slackMessageFactory,
         clock = Clock.System,
     )

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackDomainComponent.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackDomainComponent.kt
@@ -94,6 +94,20 @@ interface SlackDomainComponent {
         slackMessageFactory = slackMessageFactory,
     )
 
+    @Provides
+    fun provideSlackEnsureAuthenticatedUseCase(
+        log: Logger,
+        slackRepository: SlackRepository,
+        slackMessageFactory: SlackMessageFactory,
+        slackConfig: SlackConfig,
+    ): SlackEnsureAuthenticatedUseCase = RealSlackEnsureAuthenticatedUseCase(
+        dispatcher = Dispatchers.Default,
+        log = log,
+        slackRepository = slackRepository,
+        slackMessageFactory = slackMessageFactory,
+        slackConfig = slackConfig,
+    )
+
     @OptIn(ExperimentalTime::class)
     @Provides
     fun provideSlackSendSearchUseCase(

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
@@ -1,0 +1,71 @@
+package com.gchristov.thecodinglove.slack.domain.usecase
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.common.kotlin.debug
+import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
+import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
+import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
+import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+
+interface SlackEnsureAuthenticatedUseCase {
+    suspend operator fun invoke(dto: Dto): Either<Throwable, Result>
+
+    sealed class Result {
+        data object Authenticated : Result()
+        data object AuthenticationPromptSent : Result()
+    }
+
+    data class Dto(
+        val userId: String,
+        val teamId: String,
+        val channelId: String,
+        val responseUrl: String,
+        val searchSessionId: String,
+        val selfDestructMinutes: Int? = null,
+    )
+}
+
+internal class RealSlackEnsureAuthenticatedUseCase(
+    private val dispatcher: CoroutineDispatcher,
+    private val log: Logger,
+    private val slackRepository: SlackRepository,
+    private val slackMessageFactory: SlackMessageFactory,
+    private val slackConfig: SlackConfig,
+) : SlackEnsureAuthenticatedUseCase {
+    private val tag = this::class.simpleName
+
+    override suspend operator fun invoke(dto: SlackEnsureAuthenticatedUseCase.Dto): Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
+        withContext(dispatcher) {
+            log.debug(tag, "Checking auth token: userId=${dto.userId}")
+            val authState = SlackAuthState(
+                searchSessionId = dto.searchSessionId,
+                channelId = dto.channelId,
+                teamId = dto.teamId,
+                userId = dto.userId,
+                responseUrl = dto.responseUrl,
+                selfDestructMinutes = dto.selfDestructMinutes,
+            )
+            slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
+                log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }
+                return@withContext sendAuthenticationPrompt(authState = authState)
+            }
+            Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated)
+        }
+
+    private suspend fun sendAuthenticationPrompt(
+        authState: SlackAuthState,
+    ): Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> {
+        log.debug(tag, "Asking user to authenticate: userId=${authState.userId}")
+        return slackRepository.postMessageToUrl(
+            url = authState.responseUrl,
+            message = slackMessageFactory.authMessage(
+                clientId = slackConfig.clientId,
+                authState = authState,
+            )
+        ).map { SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent }
+    }
+}

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
@@ -52,13 +52,12 @@ internal class RealSlackEnsureAuthenticatedUseCase(
             slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }
                 return@withContext sendAuthenticationPrompt(authState = authState)
+                    .map { SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent }
             }
             Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated)
         }
 
-    private suspend fun sendAuthenticationPrompt(
-        authState: SlackAuthState,
-    ): Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> {
+    private suspend fun sendAuthenticationPrompt(authState: SlackAuthState): Either<Throwable, Unit> {
         log.debug(tag, "Asking user to authenticate: userId=${authState.userId}")
         return slackRepository.postMessageToUrl(
             url = authState.responseUrl,
@@ -66,6 +65,6 @@ internal class RealSlackEnsureAuthenticatedUseCase(
                 clientId = slackConfig.clientId,
                 authState = authState,
             )
-        ).map { SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent }
+        )
     }
 }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
@@ -6,7 +6,6 @@ import co.touchlab.kermit.Logger
 import com.gchristov.thecodinglove.common.kotlin.debug
 import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
-import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
 import com.gchristov.thecodinglove.slack.domain.model.SlackSelfDestructMessage
 import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
@@ -20,9 +19,13 @@ import kotlinx.datetime.plus
 interface SlackSendSearchUseCase {
     /**
      * @return the [SlackSelfDestructMessage] to schedule for deletion if the sent message should
-     * self-destruct, or `null` if no message was sent (yet) or it isn't self-destructing.
+     * self-destruct, or `null` if it isn't self-destructing.
      */
     suspend operator fun invoke(dto: Dto): Either<Throwable, SlackSelfDestructMessage?>
+
+    sealed class Error(message: String? = null) : Throwable(message) {
+        data object NotAuthenticated : Error("User is not authenticated")
+    }
 
     data class Dto(
         val userId: String,
@@ -41,7 +44,6 @@ internal class RealSlackSendSearchUseCase(
     private val slackSearchRepository: SlackSearchRepository,
     private val slackRepository: SlackRepository,
     private val slackMessageFactory: SlackMessageFactory,
-    private val slackConfig: SlackConfig,
     private val clock: Clock,
 ) : SlackSendSearchUseCase {
     private val tag = this::class.simpleName
@@ -59,25 +61,10 @@ internal class RealSlackSendSearchUseCase(
             )
             val token = slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }
-                return@withContext authenticate(clientId = slackConfig.clientId, authState = authState)
+                return@withContext Either.Left(SlackSendSearchUseCase.Error.NotAuthenticated)
             }
             sendResult(authState = authState, authToken = token.token)
         }
-
-    private suspend fun authenticate(
-        clientId: String,
-        authState: SlackAuthState,
-    ): Either<Throwable, SlackSelfDestructMessage?> {
-        log.debug(tag, "Asking user to authenticate: userId=${authState.userId}")
-        // No message was sent - the user still needs to authenticate - so there's nothing to self-destruct yet.
-        return slackRepository.postMessageToUrl(
-            url = authState.responseUrl,
-            message = slackMessageFactory.authMessage(
-                clientId = clientId,
-                authState = authState,
-            )
-        ).map { null }
-    }
 
     private suspend fun sendResult(
         authState: SlackAuthState,

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
@@ -1,0 +1,77 @@
+package com.gchristov.thecodinglove.slack.domain.usecase
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import com.gchristov.thecodinglove.common.slack.model.SlackAuthToken
+import com.gchristov.thecodinglove.common.test.FakeCoroutineDispatcher
+import com.gchristov.thecodinglove.common.test.FakeLogger
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackMessageFactory
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackRepository
+import com.gchristov.thecodinglove.slack.testfixtures.SlackAuthTokenCreator
+import com.gchristov.thecodinglove.slack.testfixtures.SlackConfigCreator
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RealSlackEnsureAuthenticatedUseCaseTest {
+    @Test
+    fun ensureAuthenticatedWithValidTokenReturnsAuthenticated(): TestResult = runBlockingTest(
+        getAuthTokenResult = Either.Right(SlackAuthTokenCreator.token()),
+    ) { useCase, repository ->
+        val actual = useCase.invoke(TestDto)
+        assertTrue { actual.isRight() }
+        assertEquals(SlackEnsureAuthenticatedUseCase.Result.Authenticated, actual.getOrElse { null })
+        repository.assertPostMessageToUrlCalledTimes(0)
+    }
+
+    @Test
+    fun ensureAuthenticatedWithNoTokenPostsAuthPromptAndReturnsAuthenticationPromptSent(): TestResult = runBlockingTest(
+        getAuthTokenResult = Either.Left(Throwable("No token")),
+    ) { useCase, repository ->
+        val actual = useCase.invoke(TestDto)
+        assertTrue { actual.isRight() }
+        assertEquals(SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent, actual.getOrElse { null })
+        repository.assertPostMessageToUrlCalledTimes(1)
+    }
+
+    @Test
+    fun ensureAuthenticatedWithNoTokenAndPromptPostFailureReturnsLeft(): TestResult = runBlockingTest(
+        getAuthTokenResult = Either.Left(Throwable("No token")),
+        postMessageToUrlResult = Either.Left(Throwable("Post failed")),
+    ) { useCase, _ ->
+        val actual = useCase.invoke(TestDto)
+        assertTrue { actual.isLeft() }
+    }
+
+    private fun runBlockingTest(
+        getAuthTokenResult: Either<Throwable, SlackAuthToken> = Either.Left(Throwable("No token")),
+        postMessageToUrlResult: Either<Throwable, Unit> = Either.Right(Unit),
+        testBlock: suspend (SlackEnsureAuthenticatedUseCase, FakeSlackRepository) -> Unit,
+    ): TestResult = runTest {
+        val repository = FakeSlackRepository(
+            getAuthTokenResult = getAuthTokenResult,
+            postMessageToUrlResult = postMessageToUrlResult,
+        )
+        testBlock(
+            RealSlackEnsureAuthenticatedUseCase(
+                dispatcher = FakeCoroutineDispatcher,
+                log = FakeLogger,
+                slackRepository = repository,
+                slackMessageFactory = FakeSlackMessageFactory(),
+                slackConfig = SlackConfigCreator.slackConfig(),
+            ),
+            repository,
+        )
+    }
+}
+
+private val TestDto = SlackEnsureAuthenticatedUseCase.Dto(
+    userId = "user_id",
+    teamId = "team_id",
+    channelId = "channel_id",
+    responseUrl = "https://response.url",
+    searchSessionId = "session_123",
+    selfDestructMinutes = null,
+)

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
@@ -5,7 +5,6 @@ import arrow.core.getOrElse
 import com.gchristov.thecodinglove.common.slack.model.SlackAuthToken
 import com.gchristov.thecodinglove.common.test.FakeCoroutineDispatcher
 import com.gchristov.thecodinglove.common.test.FakeLogger
-import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
 import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackMessageFactory
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackRepository
@@ -18,6 +17,7 @@ import kotlin.time.Instant
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -25,13 +25,13 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalTime::class)
 class RealSlackSendSearchUseCaseTest {
     @Test
-    fun sendWithNoAuthTokenPostsAuthMessage(): TestResult = runBlockingTest(
+    fun sendWithNoAuthTokenReturnsNotAuthenticatedError(): TestResult = runBlockingTest(
         getAuthTokenResult = Either.Left(Throwable("No token")),
     ) { useCase, repository, searchRepository ->
         val actual = useCase.invoke(TestDto)
-        assertTrue { actual.isRight() }
-        repository.assertPostMessageToUrlCalledTimes(1)
-        repository.assertPostMessageNotCalled()
+        assertTrue { actual.isLeft() }
+        assertEquals(SlackSendSearchUseCase.Error.NotAuthenticated, actual.leftOrNull())
+        repository.assertPostMessageToUrlCalledTimes(0)
         searchRepository.assertGetSessionPostNotInvoked()
     }
 
@@ -119,7 +119,6 @@ class RealSlackSendSearchUseCaseTest {
                 slackSearchRepository = searchRepository,
                 slackRepository = repository,
                 slackMessageFactory = FakeSlackMessageFactory(),
-                slackConfig = TestSlackConfig,
                 clock = TestClock,
             ),
             repository,
@@ -135,16 +134,6 @@ private val TestDto = SlackSendSearchUseCase.Dto(
     responseUrl = "https://response.url",
     searchSessionId = "session_123",
     selfDestructMinutes = null,
-)
-private val TestSlackConfig = SlackConfig(
-    signingSecret = "signing_secret",
-    timestampValidityMinutes = 5,
-    requestVerificationEnabled = true,
-    clientId = "client_id",
-    clientSecret = "client_secret",
-    interactivityReceivedPubSubTopic = "interactivity_topic",
-    slashCommandReceivedPubSubTopic = "slash_topic",
-    selfDestructMessagePubSubTopic = "self_destruct_message_topic",
 )
 @OptIn(ExperimentalTime::class)
 private val TestClock = object : Clock {

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackEnsureAuthenticatedUseCase.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackEnsureAuthenticatedUseCase.kt
@@ -1,0 +1,20 @@
+package com.gchristov.thecodinglove.slack.testfixtures
+
+import arrow.core.Either
+import com.gchristov.thecodinglove.slack.domain.usecase.SlackEnsureAuthenticatedUseCase
+import kotlin.test.assertEquals
+
+class FakeSlackEnsureAuthenticatedUseCase(
+    private val invocationResult: Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
+        Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated),
+) : SlackEnsureAuthenticatedUseCase {
+    private var invocations = 0
+
+    override suspend fun invoke(dto: SlackEnsureAuthenticatedUseCase.Dto): Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> {
+        invocations++
+        return invocationResult
+    }
+
+    fun assertInvokedOnce() = assertEquals(expected = 1, actual = invocations)
+    fun assertNotInvoked() = assertEquals(expected = 0, actual = invocations)
+}


### PR DESCRIPTION
## What does this pull request change?

When a user picks a GIF and asks TheCodingLove Slack app to send it, the same piece of code was responsible both for checking whether the user had already authorized the app and for actually posting the message, silently switching between the two behaviors depending on what it found. That made the send flow hard to follow and to test, since a caller couldn't tell from the outcome whether a message had actually gone out or the user had merely been prompted to connect their account again. This change separates those two concerns: checking authorization and prompting the user to reconnect if needed now happens up front, before the app ever attempts to send anything, while the sending logic itself simply reports back if it's ever invoked without a valid connection. The result is the same user-facing behavior — GIFs are sent immediately when already authorized, and the reconnect prompt appears otherwise — but the underlying flow is now much easier to reason about and to extend going forward.

## How is this change tested?

New and updated unit tests cover both the authorization check and the simplified send flow, including the reconnect-prompt and already-authorized paths. `./gradlew build` passes for the `slack` microservice (compiles, DI graph resolves, all unit tests pass), and all CI checks on this PR are green.

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)