### PR TITLE
[TAS-385] Add a delay picker for self-destructing messages

### DIFF
--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchSessionMapper.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchSessionMapper.kt
@@ -8,4 +8,5 @@ internal fun SearchSession.toSearchSessionPost() = ApiSearchSessionPost(
     attachmentTitle = currentPost!!.title,
     attachmentUrl = currentPost!!.url,
     attachmentImageUrl = currentPost!!.imageUrl,
+    searchResults = totalPosts ?: 0,
 )

--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchSessionMapper.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/mapper/SearchSessionMapper.kt
@@ -8,5 +8,5 @@ internal fun SearchSession.toSearchSessionPost() = ApiSearchSessionPost(
     attachmentTitle = currentPost!!.title,
     attachmentUrl = currentPost!!.url,
     attachmentImageUrl = currentPost!!.imageUrl,
-    searchResults = totalPosts ?: 0,
+    totalPosts = totalPosts!!,
 )

--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/model/ApiSearchSessionPost.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/model/ApiSearchSessionPost.kt
@@ -9,5 +9,5 @@ internal data class ApiSearchSessionPost(
     @SerialName("attachment_title") val attachmentTitle: String,
     @SerialName("attachment_url") val attachmentUrl: String,
     @SerialName("attachment_image_url") val attachmentImageUrl: String,
-    @SerialName("search_results") val searchResults: Int,
+    @SerialName("total_posts") val totalPosts: Int,
 )

--- a/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/model/ApiSearchSessionPost.kt
+++ b/search/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/search/adapter/http/model/ApiSearchSessionPost.kt
@@ -9,4 +9,5 @@ internal data class ApiSearchSessionPost(
     @SerialName("attachment_title") val attachmentTitle: String,
     @SerialName("attachment_url") val attachmentUrl: String,
     @SerialName("attachment_image_url") val attachmentImageUrl: String,
+    @SerialName("search_results") val searchResults: Int,
 )

--- a/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchSessionPostHttpHandlerTest.kt
+++ b/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchSessionPostHttpHandlerTest.kt
@@ -44,13 +44,30 @@ class SearchSessionPostHttpHandlerTest {
         searchSession = SearchSessionCreator.searchSession(
             id = TestSessionId,
             query = "kotlin",
-        ).copy(currentPost = SearchPostCreator.defaultPost()),
+        ).copy(currentPost = SearchPostCreator.defaultPost(), totalPosts = 5),
     ) { handler, response ->
         handler.handleHttpRequest(FakeSearchHttpRequest(fakeSearchSessionId = TestSessionId), response)
         response.assertEquals(
             header = "Content-Type",
             headerValue = ContentType.Application.Json.toString(),
-            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl"}""",
+            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl","search_results":5}""",
+            status = 200,
+            filePath = null,
+        )
+    }
+
+    @Test
+    fun sessionFoundWithNoTotalPostsDefaultsSearchResultsToZero(): TestResult = runBlockingTest(
+        searchSession = SearchSessionCreator.searchSession(
+            id = TestSessionId,
+            query = "kotlin",
+        ).copy(currentPost = SearchPostCreator.defaultPost(), totalPosts = null),
+    ) { handler, response ->
+        handler.handleHttpRequest(FakeSearchHttpRequest(fakeSearchSessionId = TestSessionId), response)
+        response.assertEquals(
+            header = "Content-Type",
+            headerValue = ContentType.Application.Json.toString(),
+            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl","search_results":0}""",
             status = 200,
             filePath = null,
         )

--- a/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchSessionPostHttpHandlerTest.kt
+++ b/search/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/search/adapter/http/SearchSessionPostHttpHandlerTest.kt
@@ -50,24 +50,7 @@ class SearchSessionPostHttpHandlerTest {
         response.assertEquals(
             header = "Content-Type",
             headerValue = ContentType.Application.Json.toString(),
-            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl","search_results":5}""",
-            status = 200,
-            filePath = null,
-        )
-    }
-
-    @Test
-    fun sessionFoundWithNoTotalPostsDefaultsSearchResultsToZero(): TestResult = runBlockingTest(
-        searchSession = SearchSessionCreator.searchSession(
-            id = TestSessionId,
-            query = "kotlin",
-        ).copy(currentPost = SearchPostCreator.defaultPost(), totalPosts = null),
-    ) { handler, response ->
-        handler.handleHttpRequest(FakeSearchHttpRequest(fakeSearchSessionId = TestSessionId), response)
-        response.assertEquals(
-            header = "Content-Type",
-            headerValue = ContentType.Application.Json.toString(),
-            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl","search_results":0}""",
+            data = """{"search_query":"kotlin","attachment_title":"post","attachment_url":"url","attachment_image_url":"imageUrl","total_posts":5}""",
             status = 200,
             filePath = null,
         )
@@ -77,7 +60,7 @@ class SearchSessionPostHttpHandlerTest {
         searchSession: SearchSession? = SearchSessionCreator.searchSession(
             id = TestSessionId,
             query = "kotlin",
-        ).copy(currentPost = SearchPostCreator.defaultPost()),
+        ).copy(currentPost = SearchPostCreator.defaultPost(), totalPosts = 5),
         testBlock: suspend (SearchSessionPostHttpHandler, FakeHttpResponse) -> Unit,
     ): TestResult = runTest {
         val response = FakeHttpResponse()

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
@@ -24,8 +24,6 @@ import com.gchristov.thecodinglove.slack.domain.usecase.*
 import kotlinx.coroutines.Dispatchers
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 @Component
 interface SlackAdapterComponent {
@@ -196,7 +194,7 @@ interface SlackAdapterComponent {
             SlackSelfDestructInteractivityPubSubHandler(
                 jsonSerializer = jsonSerializer,
                 actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
-                selfDestructDelay = 30.seconds,
+                selfDestructSeconds = 30L,
                 slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 pubSubPublisher = pubSubPublisher,
@@ -206,7 +204,7 @@ interface SlackAdapterComponent {
             SlackSelfDestructInteractivityPubSubHandler(
                 jsonSerializer = jsonSerializer,
                 actionName = SlackActionName.SELF_DESTRUCT_1_MIN,
-                selfDestructDelay = 1.minutes,
+                selfDestructSeconds = 60L,
                 slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 pubSubPublisher = pubSubPublisher,
@@ -216,7 +214,7 @@ interface SlackAdapterComponent {
             SlackSelfDestructInteractivityPubSubHandler(
                 jsonSerializer = jsonSerializer,
                 actionName = SlackActionName.SELF_DESTRUCT_5_MIN,
-                selfDestructDelay = 5.minutes,
+                selfDestructSeconds = 300L,
                 slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 pubSubPublisher = pubSubPublisher,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/SlackAdapterComponent.kt
@@ -15,6 +15,7 @@ import com.gchristov.thecodinglove.slack.adapter.search.RealSlackSearchRepositor
 import com.gchristov.thecodinglove.slack.adapter.search.SlackSearchServiceApi
 import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
 import com.gchristov.thecodinglove.slack.domain.model.Environment
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
 import com.gchristov.thecodinglove.slack.domain.port.SlackAuthStateSerializer
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
@@ -23,6 +24,8 @@ import com.gchristov.thecodinglove.slack.domain.usecase.*
 import kotlinx.coroutines.Dispatchers
 import me.tatarka.inject.annotations.Component
 import me.tatarka.inject.annotations.Provides
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 @Component
 interface SlackAdapterComponent {
@@ -161,6 +164,9 @@ interface SlackAdapterComponent {
         slackSendSearchUseCase: SlackSendSearchUseCase,
         slackShuffleSearchUseCase: SlackShuffleSearchUseCase,
         slackCancelSearchUseCase: SlackCancelSearchUseCase,
+        slackSearchRepository: SlackSearchRepository,
+        slackRepository: SlackRepository,
+        slackMessageFactory: SlackMessageFactory,
         pubSubDecoder: PubSubDecoder,
         pubSubPublisher: PubSubPublisher,
         slackConfig: SlackConfig,
@@ -175,8 +181,42 @@ interface SlackAdapterComponent {
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 analytics = analytics,
             ),
+            SlackSelfDestructMenuInteractivityPubSubHandler(
+                slackSearchRepository = slackSearchRepository,
+                slackRepository = slackRepository,
+                slackMessageFactory = slackMessageFactory,
+                analytics = analytics,
+            ),
+            SlackSelfDestructMenuBackInteractivityPubSubHandler(
+                slackSearchRepository = slackSearchRepository,
+                slackRepository = slackRepository,
+                slackMessageFactory = slackMessageFactory,
+                analytics = analytics,
+            ),
             SlackSelfDestructInteractivityPubSubHandler(
                 jsonSerializer = jsonSerializer,
+                actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
+                selfDestructDelay = 30.seconds,
+                slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
+                slackSendSearchUseCase = slackSendSearchUseCase,
+                pubSubPublisher = pubSubPublisher,
+                slackConfig = slackConfig,
+                analytics = analytics,
+            ),
+            SlackSelfDestructInteractivityPubSubHandler(
+                jsonSerializer = jsonSerializer,
+                actionName = SlackActionName.SELF_DESTRUCT_1_MIN,
+                selfDestructDelay = 1.minutes,
+                slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
+                slackSendSearchUseCase = slackSendSearchUseCase,
+                pubSubPublisher = pubSubPublisher,
+                slackConfig = slackConfig,
+                analytics = analytics,
+            ),
+            SlackSelfDestructInteractivityPubSubHandler(
+                jsonSerializer = jsonSerializer,
+                actionName = SlackActionName.SELF_DESTRUCT_5_MIN,
+                selfDestructDelay = 5.minutes,
                 slackEnsureAuthenticatedUseCase = slackEnsureAuthenticatedUseCase,
                 slackSendSearchUseCase = slackSendSearchUseCase,
                 pubSubPublisher = pubSubPublisher,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandler.kt
@@ -116,7 +116,7 @@ class SlackAuthHttpHandler(
                 channelId = authState.channelId,
                 responseUrl = authState.responseUrl,
                 searchSessionId = authState.searchSessionId,
-                selfDestructMinutes = authState.selfDestructMinutes,
+                selfDestructDelay = authState.selfDestructDelay,
             )
         )
     } catch (error: Throwable) {

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandler.kt
@@ -116,7 +116,7 @@ class SlackAuthHttpHandler(
                 channelId = authState.channelId,
                 responseUrl = authState.responseUrl,
                 searchSessionId = authState.searchSessionId,
-                selfDestructDelay = authState.selfDestructDelay,
+                selfDestructSeconds = authState.selfDestructSeconds,
             )
         )
     } catch (error: Throwable) {

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/mapper/SlackAuthMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/mapper/SlackAuthMapper.kt
@@ -2,6 +2,7 @@ package com.gchristov.thecodinglove.slack.adapter.http.mapper
 
 import com.gchristov.thecodinglove.slack.adapter.http.model.ApiSlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
+import kotlin.time.Duration.Companion.seconds
 
 internal fun SlackAuthState.toAuthState() = ApiSlackAuthState(
     searchSessionId = searchSessionId,
@@ -9,7 +10,7 @@ internal fun SlackAuthState.toAuthState() = ApiSlackAuthState(
     teamId = teamId,
     userId = userId,
     responseUrl = responseUrl,
-    selfDestructMinutes = selfDestructMinutes,
+    selfDestructDelaySeconds = selfDestructDelay?.inWholeSeconds,
 )
 
 internal fun ApiSlackAuthState.toAuthState() = SlackAuthState(
@@ -18,5 +19,5 @@ internal fun ApiSlackAuthState.toAuthState() = SlackAuthState(
     teamId = teamId,
     userId = userId,
     responseUrl = responseUrl,
-    selfDestructMinutes = selfDestructMinutes,
+    selfDestructDelay = selfDestructDelaySeconds?.seconds,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/mapper/SlackAuthMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/mapper/SlackAuthMapper.kt
@@ -2,7 +2,6 @@ package com.gchristov.thecodinglove.slack.adapter.http.mapper
 
 import com.gchristov.thecodinglove.slack.adapter.http.model.ApiSlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
-import kotlin.time.Duration.Companion.seconds
 
 internal fun SlackAuthState.toAuthState() = ApiSlackAuthState(
     searchSessionId = searchSessionId,
@@ -10,7 +9,7 @@ internal fun SlackAuthState.toAuthState() = ApiSlackAuthState(
     teamId = teamId,
     userId = userId,
     responseUrl = responseUrl,
-    selfDestructDelaySeconds = selfDestructDelay?.inWholeSeconds,
+    selfDestructSeconds = selfDestructSeconds,
 )
 
 internal fun ApiSlackAuthState.toAuthState() = SlackAuthState(
@@ -19,5 +18,7 @@ internal fun ApiSlackAuthState.toAuthState() = SlackAuthState(
     teamId = teamId,
     userId = userId,
     responseUrl = responseUrl,
-    selfDestructDelay = selfDestructDelaySeconds?.seconds,
+    // self_destruct_seconds is the current field; self_destruct_minutes is decoded here only to
+    // keep already-encoded (pre-deploy) state URLs working until they naturally expire.
+    selfDestructSeconds = selfDestructSeconds ?: selfDestructMinutes?.let { it * 60L },
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/model/ApiSlackAuth.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/model/ApiSlackAuth.kt
@@ -10,5 +10,6 @@ internal data class ApiSlackAuthState(
     @SerialName("team_id") val teamId: String,
     @SerialName("user_id") val userId: String,
     @SerialName("response_url") val responseUrl: String,
-    @SerialName("self_destruct_delay_seconds") val selfDestructDelaySeconds: Long?,
+    @SerialName("self_destruct_minutes") val selfDestructMinutes: Int? = null,
+    @SerialName("self_destruct_seconds") val selfDestructSeconds: Long? = null,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/model/ApiSlackAuth.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/http/model/ApiSlackAuth.kt
@@ -10,5 +10,5 @@ internal data class ApiSlackAuthState(
     @SerialName("team_id") val teamId: String,
     @SerialName("user_id") val userId: String,
     @SerialName("response_url") val responseUrl: String,
-    @SerialName("self_destruct_minutes") val selfDestructMinutes: Int?,
+    @SerialName("self_destruct_delay_seconds") val selfDestructDelaySeconds: Long?,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
@@ -18,14 +18,13 @@ import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.DeserializationStrategy
 import kotlin.time.Clock
-import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 internal class SlackSelfDestructInteractivityPubSubHandler(
     override val jsonSerializer: JsonSerializer,
     private val actionName: SlackActionName,
-    private val selfDestructDelay: Duration,
+    private val selfDestructSeconds: Long,
     private val slackEnsureAuthenticatedUseCase: SlackEnsureAuthenticatedUseCase,
     private val slackSendSearchUseCase: SlackSendSearchUseCase,
     private val pubSubPublisher: PubSubPublisher,
@@ -48,7 +47,7 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
             params = mapOf(
                 "user_id" to event.user.id,
                 "team_id" to event.team.id,
-                "self_destruct_seconds" to selfDestructDelay.inWholeSeconds.toString(),
+                "self_destruct_seconds" to selfDestructSeconds.toString(),
             ),
         )
         // Check auth before sending - if the user isn't authenticated, a prompt is sent instead and
@@ -60,7 +59,7 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructDelay = selfDestructDelay,
+                selfDestructSeconds = selfDestructSeconds,
             )
         ).getOrElse { return Either.Left(it) }
         if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
@@ -74,7 +73,7 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructDelay = selfDestructDelay,
+                selfDestructSeconds = selfDestructSeconds,
             )
         ).getOrElse { return Either.Left(it) }
         if (!sentMessage.isSelfDestruct) {

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandler.kt
@@ -18,11 +18,14 @@ import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.serialization.DeserializationStrategy
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 internal class SlackSelfDestructInteractivityPubSubHandler(
     override val jsonSerializer: JsonSerializer,
+    private val actionName: SlackActionName,
+    private val selfDestructDelay: Duration,
     private val slackEnsureAuthenticatedUseCase: SlackEnsureAuthenticatedUseCase,
     private val slackSendSearchUseCase: SlackSendSearchUseCase,
     private val pubSubPublisher: PubSubPublisher,
@@ -37,12 +40,16 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
 
     @OptIn(ExperimentalTime::class)
     override suspend fun handle(event: SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage): Either<Throwable, Unit> {
-        val action = event.actions.firstOrNull { it.name == SlackActionName.SELF_DESTRUCT_5_MIN.apiValue }
+        val action = event.actions.firstOrNull { it.name == actionName.apiValue }
             ?: return Either.Right(Unit)
         analytics.sendEvent(
             clientId = event.user.id,
             name = "slack_interactivity_self_destruct",
-            params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
+            params = mapOf(
+                "user_id" to event.user.id,
+                "team_id" to event.team.id,
+                "self_destruct_seconds" to selfDestructDelay.inWholeSeconds.toString(),
+            ),
         )
         // Check auth before sending - if the user isn't authenticated, a prompt is sent instead and
         // there's nothing left to do here.
@@ -53,7 +60,7 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructMinutes = 5,
+                selfDestructDelay = selfDestructDelay,
             )
         ).getOrElse { return Either.Left(it) }
         if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
@@ -67,7 +74,7 @@ internal class SlackSelfDestructInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructMinutes = 5,
+                selfDestructDelay = selfDestructDelay,
             )
         ).getOrElse { return Either.Left(it) }
         if (!sentMessage.isSelfDestruct) {

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandler.kt
@@ -1,0 +1,52 @@
+package com.gchristov.thecodinglove.slack.adapter.pubsub
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.common.analytics.Analytics
+import com.gchristov.thecodinglove.common.kotlin.JsonSerializer
+import com.gchristov.thecodinglove.common.pubsub.PubSubDecoder
+import com.gchristov.thecodinglove.common.pubsub.PubSubHandler
+import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackInteractivityReceivedEvent
+import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
+import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
+import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.serialization.DeserializationStrategy
+
+internal class SlackSelfDestructMenuBackInteractivityPubSubHandler(
+    private val slackSearchRepository: SlackSearchRepository,
+    private val slackRepository: SlackRepository,
+    private val slackMessageFactory: SlackMessageFactory,
+    private val analytics: Analytics,
+) : PubSubHandler<SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage> {
+    override val dispatcher: CoroutineDispatcher get() = error("not used")
+    override val jsonSerializer: JsonSerializer get() = error("not used")
+    override val log: Logger get() = error("not used")
+    override val pubSubDecoder: PubSubDecoder get() = error("not used")
+    override val strategy: DeserializationStrategy<SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage> get() = error("not used")
+    override fun httpConfig() = error("not used")
+
+    override suspend fun handle(event: SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage): Either<Throwable, Unit> {
+        val action = event.actions.firstOrNull { it.name == SlackActionName.SELF_DESTRUCT_MENU_BACK.apiValue }
+            ?: return Either.Right(Unit)
+        analytics.sendEvent(
+            clientId = event.user.id,
+            name = "slack_interactivity_self_destruct_menu_back",
+            params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
+        )
+        val post = slackSearchRepository.getSearchSessionPost(action.value).getOrElse { return Either.Left(it) }
+        return slackRepository.postMessageToUrl(
+            url = event.responseUrl,
+            message = slackMessageFactory.searchResultMessage(
+                searchQuery = post.searchQuery,
+                searchResults = post.searchResults,
+                searchSessionId = action.value,
+                attachmentTitle = post.attachmentTitle,
+                attachmentUrl = post.attachmentUrl,
+                attachmentImageUrl = post.attachmentImageUrl,
+            ),
+        )
+    }
+}

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandler.kt
@@ -41,7 +41,7 @@ internal class SlackSelfDestructMenuBackInteractivityPubSubHandler(
             url = event.responseUrl,
             message = slackMessageFactory.searchResultMessage(
                 searchQuery = post.searchQuery,
-                searchResults = post.searchResults,
+                searchResults = post.totalPosts,
                 searchSessionId = action.value,
                 attachmentTitle = post.attachmentTitle,
                 attachmentUrl = post.attachmentUrl,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandler.kt
@@ -1,0 +1,52 @@
+package com.gchristov.thecodinglove.slack.adapter.pubsub
+
+import arrow.core.Either
+import arrow.core.getOrElse
+import co.touchlab.kermit.Logger
+import com.gchristov.thecodinglove.common.analytics.Analytics
+import com.gchristov.thecodinglove.common.kotlin.JsonSerializer
+import com.gchristov.thecodinglove.common.pubsub.PubSubDecoder
+import com.gchristov.thecodinglove.common.pubsub.PubSubHandler
+import com.gchristov.thecodinglove.slack.adapter.pubsub.model.SlackInteractivityReceivedEvent
+import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
+import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
+import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.serialization.DeserializationStrategy
+
+internal class SlackSelfDestructMenuInteractivityPubSubHandler(
+    private val slackSearchRepository: SlackSearchRepository,
+    private val slackRepository: SlackRepository,
+    private val slackMessageFactory: SlackMessageFactory,
+    private val analytics: Analytics,
+) : PubSubHandler<SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage> {
+    override val dispatcher: CoroutineDispatcher get() = error("not used")
+    override val jsonSerializer: JsonSerializer get() = error("not used")
+    override val log: Logger get() = error("not used")
+    override val pubSubDecoder: PubSubDecoder get() = error("not used")
+    override val strategy: DeserializationStrategy<SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage> get() = error("not used")
+    override fun httpConfig() = error("not used")
+
+    override suspend fun handle(event: SlackInteractivityReceivedEvent.InteractivityPayload.InteractiveMessage): Either<Throwable, Unit> {
+        val action = event.actions.firstOrNull { it.name == SlackActionName.SELF_DESTRUCT_MENU.apiValue }
+            ?: return Either.Right(Unit)
+        analytics.sendEvent(
+            clientId = event.user.id,
+            name = "slack_interactivity_self_destruct_menu",
+            params = mapOf("user_id" to event.user.id, "team_id" to event.team.id),
+        )
+        val post = slackSearchRepository.getSearchSessionPost(action.value).getOrElse { return Either.Left(it) }
+        return slackRepository.postMessageToUrl(
+            url = event.responseUrl,
+            message = slackMessageFactory.searchResultDelayMenuMessage(
+                searchQuery = post.searchQuery,
+                searchResults = post.searchResults,
+                searchSessionId = action.value,
+                attachmentTitle = post.attachmentTitle,
+                attachmentUrl = post.attachmentUrl,
+                attachmentImageUrl = post.attachmentImageUrl,
+            ),
+        )
+    }
+}

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandler.kt
@@ -41,7 +41,7 @@ internal class SlackSelfDestructMenuInteractivityPubSubHandler(
             url = event.responseUrl,
             message = slackMessageFactory.searchResultDelayMenuMessage(
                 searchQuery = post.searchQuery,
-                searchResults = post.searchResults,
+                searchResults = post.totalPosts,
                 searchSessionId = action.value,
                 attachmentTitle = post.attachmentTitle,
                 attachmentUrl = post.attachmentUrl,

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
@@ -43,14 +43,14 @@ internal class SlackSendInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructDelay = null,
+                selfDestructSeconds = null,
             )
         ).getOrElse { return Either.Left(it) }
         if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
             return Either.Right(Unit)
         }
 
-        // This flow never self-destructs (selfDestructDelay = null), so there's never anything to
+        // This flow never self-destructs (selfDestructSeconds = null), so there's never anything to
         // schedule - discard the returned SlackSentMessage to satisfy PubSubHandler's Unit contract.
         return slackSendSearchUseCase(
             SlackSendSearchUseCase.Dto(
@@ -59,7 +59,7 @@ internal class SlackSendInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructDelay = null,
+                selfDestructSeconds = null,
             )
         ).map { }
     }

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandler.kt
@@ -43,14 +43,14 @@ internal class SlackSendInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructMinutes = null,
+                selfDestructDelay = null,
             )
         ).getOrElse { return Either.Left(it) }
         if (authResult == SlackEnsureAuthenticatedUseCase.Result.AuthenticationPromptSent) {
             return Either.Right(Unit)
         }
 
-        // This flow never self-destructs (selfDestructMinutes = null), so there's never anything to
+        // This flow never self-destructs (selfDestructDelay = null), so there's never anything to
         // schedule - discard the returned SlackSentMessage to satisfy PubSubHandler's Unit contract.
         return slackSendSearchUseCase(
             SlackSendSearchUseCase.Dto(
@@ -59,7 +59,7 @@ internal class SlackSendInteractivityPubSubHandler(
                 channelId = event.channel.id,
                 responseUrl = event.responseUrl,
                 searchSessionId = action.value,
-                selfDestructMinutes = null,
+                selfDestructDelay = null,
             )
         ).map { }
     }

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapper.kt
@@ -16,13 +16,13 @@ private fun ApiSlackSearchResult.ApiError.toSearchError() = when (this) {
 private fun ApiSlackSearchResult.ApiSearchSession.toSearchSession() = SlackSearchRepository.SearchResultDto.SearchSession(
     searchSessionId = searchSessionId,
     searchResults = totalPosts,
-    post = post.toPost(query = query, searchResults = totalPosts)
+    post = post.toPost(query = query, totalPosts = totalPosts)
 )
 
-private fun ApiSlackSearchResult.ApiPost.toPost(query: String, searchResults: Int) = SlackSearchRepository.SearchSessionPostDto(
+private fun ApiSlackSearchResult.ApiPost.toPost(query: String, totalPosts: Int) = SlackSearchRepository.SearchSessionPostDto(
     searchQuery = query,
     attachmentTitle = title,
     attachmentUrl = url,
     attachmentImageUrl = imageUrl,
-    searchResults = searchResults,
+    totalPosts = totalPosts,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapper.kt
@@ -16,12 +16,13 @@ private fun ApiSlackSearchResult.ApiError.toSearchError() = when (this) {
 private fun ApiSlackSearchResult.ApiSearchSession.toSearchSession() = SlackSearchRepository.SearchResultDto.SearchSession(
     searchSessionId = searchSessionId,
     searchResults = totalPosts,
-    post = post.toPost(query)
+    post = post.toPost(query = query, searchResults = totalPosts)
 )
 
-private fun ApiSlackSearchResult.ApiPost.toPost(query: String) = SlackSearchRepository.SearchSessionPostDto(
+private fun ApiSlackSearchResult.ApiPost.toPost(query: String, searchResults: Int) = SlackSearchRepository.SearchSessionPostDto(
     searchQuery = query,
     attachmentTitle = title,
     attachmentUrl = url,
     attachmentImageUrl = imageUrl,
+    searchResults = searchResults,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapper.kt
@@ -8,4 +8,5 @@ internal fun ApiSlackSearchSessionPost.toSearchSessionPost() = SlackSearchReposi
     attachmentTitle = attachmentTitle,
     attachmentUrl = attachmentUrl,
     attachmentImageUrl = attachmentImageUrl,
+    searchResults = searchResults,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapper.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapper.kt
@@ -8,5 +8,5 @@ internal fun ApiSlackSearchSessionPost.toSearchSessionPost() = SlackSearchReposi
     attachmentTitle = attachmentTitle,
     attachmentUrl = attachmentUrl,
     attachmentImageUrl = attachmentImageUrl,
-    searchResults = searchResults,
+    totalPosts = totalPosts,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/model/ApiSlackSearchSessionPost.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/model/ApiSlackSearchSessionPost.kt
@@ -9,4 +9,5 @@ internal data class ApiSlackSearchSessionPost(
     @SerialName("attachment_title") val attachmentTitle: String,
     @SerialName("attachment_url") val attachmentUrl: String,
     @SerialName("attachment_image_url") val attachmentImageUrl: String,
+    @SerialName("search_results") val searchResults: Int,
 )

--- a/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/model/ApiSlackSearchSessionPost.kt
+++ b/slack/adapter/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/adapter/search/model/ApiSlackSearchSessionPost.kt
@@ -9,5 +9,5 @@ internal data class ApiSlackSearchSessionPost(
     @SerialName("attachment_title") val attachmentTitle: String,
     @SerialName("attachment_url") val attachmentUrl: String,
     @SerialName("attachment_image_url") val attachmentImageUrl: String,
-    @SerialName("search_results") val searchResults: Int,
+    @SerialName("total_posts") val totalPosts: Int,
 )

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/RealSlackAuthStateSerializerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/RealSlackAuthStateSerializerTest.kt
@@ -7,6 +7,7 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import io.ktor.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.minutes
 
 class RealSlackAuthStateSerializerTest {
     private val serializer = RealSlackAuthStateSerializer(JsonSerializer.Default)
@@ -20,8 +21,8 @@ class RealSlackAuthStateSerializerTest {
     }
 
     @Test
-    fun selfDestructMinutesNullPreserved() {
-        val state = TestAuthState.copy(selfDestructMinutes = null)
+    fun selfDestructDelayNullPreserved() {
+        val state = TestAuthState.copy(selfDestructDelay = null)
         val result = serializer.serialize(state)
         val decoded = result.decodeBase64String()
         val parsed = JsonSerializer.Default.json.decodeFromString<ApiSlackAuthState>(decoded).toAuthState()
@@ -29,8 +30,8 @@ class RealSlackAuthStateSerializerTest {
     }
 
     @Test
-    fun selfDestructMinutesValuePreserved() {
-        val state = TestAuthState.copy(selfDestructMinutes = 5)
+    fun selfDestructDelayValuePreserved() {
+        val state = TestAuthState.copy(selfDestructDelay = 5.minutes)
         val result = serializer.serialize(state)
         val decoded = result.decodeBase64String()
         val parsed = JsonSerializer.Default.json.decodeFromString<ApiSlackAuthState>(decoded).toAuthState()
@@ -44,5 +45,5 @@ private val TestAuthState = SlackAuthState(
     teamId = "team_xyz",
     userId = "user_456",
     responseUrl = "https://response.url",
-    selfDestructMinutes = null,
+    selfDestructDelay = null,
 )

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/RealSlackAuthStateSerializerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/RealSlackAuthStateSerializerTest.kt
@@ -7,7 +7,6 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import io.ktor.util.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.time.Duration.Companion.minutes
 
 class RealSlackAuthStateSerializerTest {
     private val serializer = RealSlackAuthStateSerializer(JsonSerializer.Default)
@@ -21,8 +20,8 @@ class RealSlackAuthStateSerializerTest {
     }
 
     @Test
-    fun selfDestructDelayNullPreserved() {
-        val state = TestAuthState.copy(selfDestructDelay = null)
+    fun selfDestructSecondsNullPreserved() {
+        val state = TestAuthState.copy(selfDestructSeconds = null)
         val result = serializer.serialize(state)
         val decoded = result.decodeBase64String()
         val parsed = JsonSerializer.Default.json.decodeFromString<ApiSlackAuthState>(decoded).toAuthState()
@@ -30,12 +29,29 @@ class RealSlackAuthStateSerializerTest {
     }
 
     @Test
-    fun selfDestructDelayValuePreserved() {
-        val state = TestAuthState.copy(selfDestructDelay = 5.minutes)
+    fun selfDestructSecondsValuePreserved() {
+        val state = TestAuthState.copy(selfDestructSeconds = 300L)
         val result = serializer.serialize(state)
         val decoded = result.decodeBase64String()
         val parsed = JsonSerializer.Default.json.decodeFromString<ApiSlackAuthState>(decoded).toAuthState()
         assertEquals(expected = state, actual = parsed)
+    }
+
+    @Test
+    fun legacySelfDestructMinutesFallsBackToSelfDestructSeconds() {
+        // Simulates decoding an already-encoded (pre-deploy) state URL that only has the legacy
+        // self_destruct_minutes field, to confirm it still resolves to a usable delay.
+        val legacyApiState = ApiSlackAuthState(
+            searchSessionId = TestAuthState.searchSessionId,
+            channelId = TestAuthState.channelId,
+            teamId = TestAuthState.teamId,
+            userId = TestAuthState.userId,
+            responseUrl = TestAuthState.responseUrl,
+            selfDestructMinutes = 5,
+            selfDestructSeconds = null,
+        )
+        val parsed = legacyApiState.toAuthState()
+        assertEquals(expected = 300L, actual = parsed.selfDestructSeconds)
     }
 }
 
@@ -45,5 +61,5 @@ private val TestAuthState = SlackAuthState(
     teamId = "team_xyz",
     userId = "user_456",
     responseUrl = "https://response.url",
-    selfDestructDelay = null,
+    selfDestructSeconds = null,
 )

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandlerTest.kt
@@ -135,6 +135,6 @@ class SlackAuthHttpHandlerTest {
 
 private const val TestSelfDestructTopic = "self_destruct_topic"
 
-// Base64 of: {"search_session_id":"session_1","channel_id":"ch_1","team_id":"team_1","user_id":"user_1","response_url":"https://response.com","self_destruct_minutes":5}
+// Base64 of: {"search_session_id":"session_1","channel_id":"ch_1","team_id":"team_1","user_id":"user_1","response_url":"https://response.com","self_destruct_delay_seconds":300}
 private const val TestEncodedState =
-    "eyJzZWFyY2hfc2Vzc2lvbl9pZCI6InNlc3Npb25fMSIsImNoYW5uZWxfaWQiOiJjaF8xIiwidGVhbV9pZCI6InRlYW1fMSIsInVzZXJfaWQiOiJ1c2VyXzEiLCJyZXNwb25zZV91cmwiOiJodHRwczovL3Jlc3BvbnNlLmNvbSIsInNlbGZfZGVzdHJ1Y3RfbWludXRlcyI6NX0="
+    "eyJzZWFyY2hfc2Vzc2lvbl9pZCI6InNlc3Npb25fMSIsImNoYW5uZWxfaWQiOiJjaF8xIiwidGVhbV9pZCI6InRlYW1fMSIsInVzZXJfaWQiOiJ1c2VyXzEiLCJyZXNwb25zZV91cmwiOiJodHRwczovL3Jlc3BvbnNlLmNvbSIsInNlbGZfZGVzdHJ1Y3RfZGVsYXlfc2Vjb25kcyI6MzAwfQ=="

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/http/SlackAuthHttpHandlerTest.kt
@@ -135,6 +135,6 @@ class SlackAuthHttpHandlerTest {
 
 private const val TestSelfDestructTopic = "self_destruct_topic"
 
-// Base64 of: {"search_session_id":"session_1","channel_id":"ch_1","team_id":"team_1","user_id":"user_1","response_url":"https://response.com","self_destruct_delay_seconds":300}
+// Base64 of: {"search_session_id":"session_1","channel_id":"ch_1","team_id":"team_1","user_id":"user_1","response_url":"https://response.com","self_destruct_seconds":300}
 private const val TestEncodedState =
-    "eyJzZWFyY2hfc2Vzc2lvbl9pZCI6InNlc3Npb25fMSIsImNoYW5uZWxfaWQiOiJjaF8xIiwidGVhbV9pZCI6InRlYW1fMSIsInVzZXJfaWQiOiJ1c2VyXzEiLCJyZXNwb25zZV91cmwiOiJodHRwczovL3Jlc3BvbnNlLmNvbSIsInNlbGZfZGVzdHJ1Y3RfZGVsYXlfc2Vjb25kcyI6MzAwfQ=="
+    "eyJzZWFyY2hfc2Vzc2lvbl9pZCI6InNlc3Npb25fMSIsImNoYW5uZWxfaWQiOiJjaF8xIiwidGVhbV9pZCI6InRlYW1fMSIsInVzZXJfaWQiOiJ1c2VyXzEiLCJyZXNwb25zZV91cmwiOiJodHRwczovL3Jlc3BvbnNlLmNvbSIsInNlbGZfZGVzdHJ1Y3Rfc2Vjb25kcyI6MzAwfQ=="

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
@@ -27,8 +27,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 class SlackInteractivityPubSubHandlerTest {
     @Test
@@ -158,7 +156,7 @@ class SlackInteractivityPubSubHandlerTest {
                 SlackSelfDestructInteractivityPubSubHandler(
                     jsonSerializer = JsonSerializer.Default,
                     actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
-                    selfDestructDelay = 30.seconds,
+                    selfDestructSeconds = 30L,
                     slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
                     slackSendSearchUseCase = sendUseCase,
                     pubSubPublisher = FakePubSubPublisher(),
@@ -168,7 +166,7 @@ class SlackInteractivityPubSubHandlerTest {
                 SlackSelfDestructInteractivityPubSubHandler(
                     jsonSerializer = JsonSerializer.Default,
                     actionName = SlackActionName.SELF_DESTRUCT_1_MIN,
-                    selfDestructDelay = 1.minutes,
+                    selfDestructSeconds = 60L,
                     slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
                     slackSendSearchUseCase = sendUseCase,
                     pubSubPublisher = FakePubSubPublisher(),
@@ -178,7 +176,7 @@ class SlackInteractivityPubSubHandlerTest {
                 SlackSelfDestructInteractivityPubSubHandler(
                     jsonSerializer = JsonSerializer.Default,
                     actionName = SlackActionName.SELF_DESTRUCT_5_MIN,
-                    selfDestructDelay = 5.minutes,
+                    selfDestructSeconds = 300L,
                     slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
                     slackSendSearchUseCase = sendUseCase,
                     pubSubPublisher = FakePubSubPublisher(),

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackInteractivityPubSubHandlerTest.kt
@@ -14,6 +14,9 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackSentMessage
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackCancelSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackEnsureAuthenticatedUseCase
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackMessageFactory
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackRepository
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSearchRepository
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSendSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackShuffleSearchUseCase
 import com.gchristov.thecodinglove.slack.testfixtures.SlackConfigCreator
@@ -24,10 +27,12 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class SlackInteractivityPubSubHandlerTest {
     @Test
-    fun httpConfig(): TestResult = runBlockingTest { handler, _, _ ->
+    fun httpConfig(): TestResult = runBlockingTest { handler, _, _, _ ->
         val config = handler.httpConfig()
         assertEquals(HttpMethod.Post, config.method)
         assertEquals("/api/pubsub/slack/interactivity", config.path)
@@ -35,28 +40,56 @@ class SlackInteractivityPubSubHandlerTest {
     }
 
     @Test
-    fun sendActionRoutesToSendHandler(): TestResult = runBlockingTest { handler, sendUseCase, _ ->
+    fun sendActionRoutesToSendHandler(): TestResult = runBlockingTest { handler, sendUseCase, _, _ ->
         val result = handler.handle(interactivityMessage(action = SlackActionName.SEND))
         assertTrue { result.isRight() }
         sendUseCase.assertInvokedOnce()
     }
 
     @Test
-    fun shuffleActionRoutesToShuffleHandler(): TestResult = runBlockingTest { handler, _, shuffleUseCase ->
+    fun shuffleActionRoutesToShuffleHandler(): TestResult = runBlockingTest { handler, _, shuffleUseCase, _ ->
         val result = handler.handle(interactivityMessage(action = SlackActionName.SHUFFLE))
         assertTrue { result.isRight() }
         shuffleUseCase.assertInvokedOnce()
     }
 
     @Test
-    fun selfDestructActionRoutesToSelfDestructHandler(): TestResult = runBlockingTest { handler, sendUseCase, _ ->
+    fun selfDestructActionRoutesToSelfDestructHandler(): TestResult = runBlockingTest { handler, sendUseCase, _, _ ->
         val result = handler.handle(interactivityMessage(action = SlackActionName.SELF_DESTRUCT_5_MIN))
         assertTrue { result.isRight() }
         sendUseCase.assertInvokedOnce()
     }
 
     @Test
-    fun cancelActionRoutesToCancelHandler(): TestResult = runBlockingTest { handler, _, _ ->
+    fun selfDestruct30SecActionRoutesToSelfDestructHandler(): TestResult = runBlockingTest { handler, sendUseCase, _, _ ->
+        val result = handler.handle(interactivityMessage(action = SlackActionName.SELF_DESTRUCT_30_SEC))
+        assertTrue { result.isRight() }
+        sendUseCase.assertInvokedOnce()
+    }
+
+    @Test
+    fun selfDestruct1MinActionRoutesToSelfDestructHandler(): TestResult = runBlockingTest { handler, sendUseCase, _, _ ->
+        val result = handler.handle(interactivityMessage(action = SlackActionName.SELF_DESTRUCT_1_MIN))
+        assertTrue { result.isRight() }
+        sendUseCase.assertInvokedOnce()
+    }
+
+    @Test
+    fun selfDestructMenuActionRoutesToSelfDestructMenuHandler(): TestResult = runBlockingTest { handler, _, _, searchRepository ->
+        val result = handler.handle(interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU))
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostInvokedOnce()
+    }
+
+    @Test
+    fun selfDestructMenuBackActionRoutesToSelfDestructMenuBackHandler(): TestResult = runBlockingTest { handler, _, _, searchRepository ->
+        val result = handler.handle(interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU_BACK))
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostInvokedOnce()
+    }
+
+    @Test
+    fun cancelActionRoutesToCancelHandler(): TestResult = runBlockingTest { handler, _, _, _ ->
         val result = handler.handle(interactivityMessage(action = SlackActionName.CANCEL))
         assertTrue { result.isRight() }
     }
@@ -64,13 +97,13 @@ class SlackInteractivityPubSubHandlerTest {
     @Test
     fun handleErrorSwallows(): TestResult = runBlockingTest(
         sendResult = Either.Left(Throwable("send failed"))
-    ) { handler, _, _ ->
+    ) { handler, _, _, _ ->
         val result = handler.handle(interactivityMessage(action = SlackActionName.SEND))
         assertTrue { result.isRight() }
     }
 
     @Test
-    fun handleParseErrorSendsEmpty(): TestResult = runBlockingTest { handler, _, _ ->
+    fun handleParseErrorSendsEmpty(): TestResult = runBlockingTest { handler, _, _, _ ->
         val response = FakeHttpResponse()
         val result = handler.handleError(Throwable("parse error"), response)
         assertTrue { result.isRight() }
@@ -85,12 +118,20 @@ class SlackInteractivityPubSubHandlerTest {
 
     private fun runBlockingTest(
         sendResult: Either<Throwable, SlackSentMessage> = Either.Right(SlackSentMessageCreator.futureMessage()),
-        testBlock: suspend (SlackInteractivityPubSubHandler, FakeSlackSendSearchUseCase, FakeSlackShuffleSearchUseCase) -> Unit,
+        testBlock: suspend (
+            SlackInteractivityPubSubHandler,
+            FakeSlackSendSearchUseCase,
+            FakeSlackShuffleSearchUseCase,
+            FakeSlackSearchRepository,
+        ) -> Unit,
     ): TestResult = runTest {
         val ensureAuthUseCase = FakeSlackEnsureAuthenticatedUseCase()
         val sendUseCase = FakeSlackSendSearchUseCase(invocationResult = sendResult)
         val shuffleUseCase = FakeSlackShuffleSearchUseCase()
         val cancelUseCase = FakeSlackCancelSearchUseCase()
+        val searchRepository = FakeSlackSearchRepository()
+        val repository = FakeSlackRepository()
+        val messageFactory = FakeSlackMessageFactory()
         val analytics = FakeAnalytics()
         val handler = SlackInteractivityPubSubHandler(
             dispatcher = FakeCoroutineDispatcher,
@@ -102,8 +143,42 @@ class SlackInteractivityPubSubHandlerTest {
                     slackSendSearchUseCase = sendUseCase,
                     analytics = analytics,
                 ),
+                SlackSelfDestructMenuInteractivityPubSubHandler(
+                    slackSearchRepository = searchRepository,
+                    slackRepository = repository,
+                    slackMessageFactory = messageFactory,
+                    analytics = analytics,
+                ),
+                SlackSelfDestructMenuBackInteractivityPubSubHandler(
+                    slackSearchRepository = searchRepository,
+                    slackRepository = repository,
+                    slackMessageFactory = messageFactory,
+                    analytics = analytics,
+                ),
                 SlackSelfDestructInteractivityPubSubHandler(
                     jsonSerializer = JsonSerializer.Default,
+                    actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
+                    selfDestructDelay = 30.seconds,
+                    slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
+                    slackSendSearchUseCase = sendUseCase,
+                    pubSubPublisher = FakePubSubPublisher(),
+                    slackConfig = SlackConfigCreator.slackConfig(),
+                    analytics = analytics,
+                ),
+                SlackSelfDestructInteractivityPubSubHandler(
+                    jsonSerializer = JsonSerializer.Default,
+                    actionName = SlackActionName.SELF_DESTRUCT_1_MIN,
+                    selfDestructDelay = 1.minutes,
+                    slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
+                    slackSendSearchUseCase = sendUseCase,
+                    pubSubPublisher = FakePubSubPublisher(),
+                    slackConfig = SlackConfigCreator.slackConfig(),
+                    analytics = analytics,
+                ),
+                SlackSelfDestructInteractivityPubSubHandler(
+                    jsonSerializer = JsonSerializer.Default,
+                    actionName = SlackActionName.SELF_DESTRUCT_5_MIN,
+                    selfDestructDelay = 5.minutes,
                     slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
                     slackSendSearchUseCase = sendUseCase,
                     pubSubPublisher = FakePubSubPublisher(),
@@ -115,7 +190,7 @@ class SlackInteractivityPubSubHandlerTest {
             ),
             pubSubDecoder = FakePubSubDecoder(FakePubSubRequest(null, SlackInteractivityReceivedEvent.serializer())),
         )
-        testBlock(handler, sendUseCase, shuffleUseCase)
+        testBlock(handler, sendUseCase, shuffleUseCase, searchRepository)
     }
 }
 

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
@@ -16,6 +16,9 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class SlackSelfDestructInteractivityPubSubHandlerTest {
     @Test
@@ -25,7 +28,20 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
         assertTrue { result.isRight() }
         ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
-        sendUseCase.assertSelfDestructMinutes(5)
+        sendUseCase.assertSelfDestructDelay(5.minutes)
+    }
+
+    @Test
+    fun handleSelfDestruct30SecInvokesSendUseCaseWith30Seconds(): TestResult = runBlockingTest(
+        actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
+        selfDestructDelay = 30.seconds,
+    ) { handler, ensureAuthUseCase, sendUseCase, _ ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_30_SEC).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        ensureAuthUseCase.assertInvokedOnce()
+        sendUseCase.assertInvokedOnce()
+        sendUseCase.assertSelfDestructDelay(30.seconds)
     }
 
     @Test
@@ -89,6 +105,8 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
     }
 
     private fun runBlockingTest(
+        actionName: SlackActionName = SlackActionName.SELF_DESTRUCT_5_MIN,
+        selfDestructDelay: Duration = 5.minutes,
         ensureAuthResult: Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
             Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated),
         sendResult: Either<Throwable, SlackSentMessage> = Either.Right(SlackSentMessageCreator.futureMessage()),
@@ -104,6 +122,8 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
         val pubSubPublisher = FakePubSubPublisher()
         val handler = SlackSelfDestructInteractivityPubSubHandler(
             jsonSerializer = JsonSerializer.Default,
+            actionName = actionName,
+            selfDestructDelay = selfDestructDelay,
             slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
             slackSendSearchUseCase = sendUseCase,
             pubSubPublisher = pubSubPublisher,

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructInteractivityPubSubHandlerTest.kt
@@ -16,9 +16,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 class SlackSelfDestructInteractivityPubSubHandlerTest {
     @Test
@@ -28,20 +25,20 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
         assertTrue { result.isRight() }
         ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
-        sendUseCase.assertSelfDestructDelay(5.minutes)
+        sendUseCase.assertSelfDestructSeconds(300L)
     }
 
     @Test
     fun handleSelfDestruct30SecInvokesSendUseCaseWith30Seconds(): TestResult = runBlockingTest(
         actionName = SlackActionName.SELF_DESTRUCT_30_SEC,
-        selfDestructDelay = 30.seconds,
+        selfDestructSeconds = 30L,
     ) { handler, ensureAuthUseCase, sendUseCase, _ ->
         val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_30_SEC).payload as SlackInteractivityPayload
         val result = handler.handle(payload)
         assertTrue { result.isRight() }
         ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
-        sendUseCase.assertSelfDestructDelay(30.seconds)
+        sendUseCase.assertSelfDestructSeconds(30L)
     }
 
     @Test
@@ -106,7 +103,7 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
 
     private fun runBlockingTest(
         actionName: SlackActionName = SlackActionName.SELF_DESTRUCT_5_MIN,
-        selfDestructDelay: Duration = 5.minutes,
+        selfDestructSeconds: Long = 300L,
         ensureAuthResult: Either<Throwable, SlackEnsureAuthenticatedUseCase.Result> =
             Either.Right(SlackEnsureAuthenticatedUseCase.Result.Authenticated),
         sendResult: Either<Throwable, SlackSentMessage> = Either.Right(SlackSentMessageCreator.futureMessage()),
@@ -123,7 +120,7 @@ class SlackSelfDestructInteractivityPubSubHandlerTest {
         val handler = SlackSelfDestructInteractivityPubSubHandler(
             jsonSerializer = JsonSerializer.Default,
             actionName = actionName,
-            selfDestructDelay = selfDestructDelay,
+            selfDestructSeconds = selfDestructSeconds,
             slackEnsureAuthenticatedUseCase = ensureAuthUseCase,
             slackSendSearchUseCase = sendUseCase,
             pubSubPublisher = pubSubPublisher,

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuBackInteractivityPubSubHandlerTest.kt
@@ -1,0 +1,74 @@
+package com.gchristov.thecodinglove.slack.adapter.pubsub
+
+import arrow.core.Either
+import com.gchristov.thecodinglove.common.analyticstestfixtures.FakeAnalytics
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
+import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackMessageFactory
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackRepository
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSearchRepository
+import com.gchristov.thecodinglove.slack.testfixtures.SlackSearchSessionPostCreator
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SlackSelfDestructMenuBackInteractivityPubSubHandlerTest {
+    @Test
+    fun handleSelfDestructMenuBackPostsMainMenuMessage(): TestResult = runBlockingTest { handler, searchRepository, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU_BACK).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostInvokedOnce()
+        repository.assertPostMessageToUrlCalledTimes(1)
+    }
+
+    @Test
+    fun handleOtherActionSkips(): TestResult = runBlockingTest { handler, searchRepository, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SEND).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostNotInvoked()
+        repository.assertPostMessageToUrlCalledTimes(0)
+    }
+
+    @Test
+    fun handleGetSessionPostErrorReturnsLeft(): TestResult = runBlockingTest(
+        getSearchSessionPostResult = Either.Left(Throwable("Session not found")),
+    ) { handler, _, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU_BACK).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+        repository.assertPostMessageToUrlCalledTimes(0)
+    }
+
+    @Test
+    fun handlePostMessageErrorReturnsLeft(): TestResult = runBlockingTest(
+        postMessageToUrlResult = Either.Left(Throwable("Post failed")),
+    ) { handler, _, _ ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU_BACK).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+    }
+
+    private fun runBlockingTest(
+        getSearchSessionPostResult: Either<Throwable, SlackSearchRepository.SearchSessionPostDto> = Either.Right(SlackSearchSessionPostCreator.post()),
+        postMessageToUrlResult: Either<Throwable, Unit> = Either.Right(Unit),
+        testBlock: suspend (
+            SlackSelfDestructMenuBackInteractivityPubSubHandler,
+            FakeSlackSearchRepository,
+            FakeSlackRepository,
+        ) -> Unit,
+    ): TestResult = runTest {
+        val searchRepository = FakeSlackSearchRepository(getSearchSessionPostResult = getSearchSessionPostResult)
+        val repository = FakeSlackRepository(postMessageToUrlResult = postMessageToUrlResult)
+        val handler = SlackSelfDestructMenuBackInteractivityPubSubHandler(
+            slackSearchRepository = searchRepository,
+            slackRepository = repository,
+            slackMessageFactory = FakeSlackMessageFactory(),
+            analytics = FakeAnalytics(),
+        )
+        testBlock(handler, searchRepository, repository)
+    }
+}

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSelfDestructMenuInteractivityPubSubHandlerTest.kt
@@ -1,0 +1,74 @@
+package com.gchristov.thecodinglove.slack.adapter.pubsub
+
+import arrow.core.Either
+import com.gchristov.thecodinglove.common.analyticstestfixtures.FakeAnalytics
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
+import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackMessageFactory
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackRepository
+import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackSearchRepository
+import com.gchristov.thecodinglove.slack.testfixtures.SlackSearchSessionPostCreator
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SlackSelfDestructMenuInteractivityPubSubHandlerTest {
+    @Test
+    fun handleSelfDestructMenuPostsDelayMenuMessage(): TestResult = runBlockingTest { handler, searchRepository, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostInvokedOnce()
+        repository.assertPostMessageToUrlCalledTimes(1)
+    }
+
+    @Test
+    fun handleOtherActionSkips(): TestResult = runBlockingTest { handler, searchRepository, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SEND).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertTrue { result.isRight() }
+        searchRepository.assertGetSessionPostNotInvoked()
+        repository.assertPostMessageToUrlCalledTimes(0)
+    }
+
+    @Test
+    fun handleGetSessionPostErrorReturnsLeft(): TestResult = runBlockingTest(
+        getSearchSessionPostResult = Either.Left(Throwable("Session not found")),
+    ) { handler, _, repository ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+        repository.assertPostMessageToUrlCalledTimes(0)
+    }
+
+    @Test
+    fun handlePostMessageErrorReturnsLeft(): TestResult = runBlockingTest(
+        postMessageToUrlResult = Either.Left(Throwable("Post failed")),
+    ) { handler, _, _ ->
+        val payload = interactivityMessage(action = SlackActionName.SELF_DESTRUCT_MENU).payload as SlackInteractivityPayload
+        val result = handler.handle(payload)
+        assertFalse { result.isRight() }
+    }
+
+    private fun runBlockingTest(
+        getSearchSessionPostResult: Either<Throwable, SlackSearchRepository.SearchSessionPostDto> = Either.Right(SlackSearchSessionPostCreator.post()),
+        postMessageToUrlResult: Either<Throwable, Unit> = Either.Right(Unit),
+        testBlock: suspend (
+            SlackSelfDestructMenuInteractivityPubSubHandler,
+            FakeSlackSearchRepository,
+            FakeSlackRepository,
+        ) -> Unit,
+    ): TestResult = runTest {
+        val searchRepository = FakeSlackSearchRepository(getSearchSessionPostResult = getSearchSessionPostResult)
+        val repository = FakeSlackRepository(postMessageToUrlResult = postMessageToUrlResult)
+        val handler = SlackSelfDestructMenuInteractivityPubSubHandler(
+            slackSearchRepository = searchRepository,
+            slackRepository = repository,
+            slackMessageFactory = FakeSlackMessageFactory(),
+            analytics = FakeAnalytics(),
+        )
+        testBlock(handler, searchRepository, repository)
+    }
+}

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
@@ -22,7 +22,7 @@ class SlackSendInteractivityPubSubHandlerTest {
         assertTrue { result.isRight() }
         ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
-        sendUseCase.assertSelfDestructDelay(null)
+        sendUseCase.assertSelfDestructSeconds(null)
     }
 
     @Test

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/pubsub/SlackSendInteractivityPubSubHandlerTest.kt
@@ -22,7 +22,7 @@ class SlackSendInteractivityPubSubHandlerTest {
         assertTrue { result.isRight() }
         ensureAuthUseCase.assertInvokedOnce()
         sendUseCase.assertInvokedOnce()
-        sendUseCase.assertSelfDestructMinutes(null)
+        sendUseCase.assertSelfDestructDelay(null)
     }
 
     @Test

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapperTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapperTest.kt
@@ -20,7 +20,7 @@ class SlackSearchResultMapperTest {
                         attachmentTitle = "Post title",
                         attachmentUrl = "https://post.url",
                         attachmentImageUrl = "https://image.url",
-                        searchResults = 42,
+                        totalPosts = 42,
                     ),
                 ),
             ),

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapperTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchResultMapperTest.kt
@@ -20,6 +20,7 @@ class SlackSearchResultMapperTest {
                         attachmentTitle = "Post title",
                         attachmentUrl = "https://post.url",
                         attachmentImageUrl = "https://image.url",
+                        searchResults = 42,
                     ),
                 ),
             ),

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapperTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapperTest.kt
@@ -14,14 +14,14 @@ class SlackSearchSessionPostMapperTest {
                 attachmentTitle = "Post title",
                 attachmentUrl = "https://post.url",
                 attachmentImageUrl = "https://image.url",
-                searchResults = 5,
+                totalPosts = 5,
             ),
             actual = ApiSlackSearchSessionPost(
                 searchQuery = "kotlin",
                 attachmentTitle = "Post title",
                 attachmentUrl = "https://post.url",
                 attachmentImageUrl = "https://image.url",
-                searchResults = 5,
+                totalPosts = 5,
             ).toSearchSessionPost(),
         )
     }

--- a/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapperTest.kt
+++ b/slack/adapter/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/adapter/search/mapper/SlackSearchSessionPostMapperTest.kt
@@ -14,12 +14,14 @@ class SlackSearchSessionPostMapperTest {
                 attachmentTitle = "Post title",
                 attachmentUrl = "https://post.url",
                 attachmentImageUrl = "https://image.url",
+                searchResults = 5,
             ),
             actual = ApiSlackSearchSessionPost(
                 searchQuery = "kotlin",
                 attachmentTitle = "Post title",
                 attachmentUrl = "https://post.url",
                 attachmentImageUrl = "https://image.url",
+                searchResults = 5,
             ).toSearchSessionPost(),
         )
     }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
@@ -6,6 +6,8 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackMessageResponseType
 import com.gchristov.thecodinglove.slack.domain.port.SlackAuthStateSerializer
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
 
 interface SlackMessageFactory {
     fun message(
@@ -30,6 +32,15 @@ interface SlackMessageFactory {
         attachmentImageUrl: String,
     ): SlackMessage
 
+    fun searchResultDelayMenuMessage(
+        searchQuery: String,
+        searchResults: Int,
+        searchSessionId: String,
+        attachmentTitle: String,
+        attachmentUrl: String,
+        attachmentImageUrl: String,
+    ): SlackMessage
+
     fun authMessage(
         clientId: String,
         authState: SlackAuthState
@@ -41,7 +52,7 @@ interface SlackMessageFactory {
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructMinutes: Int?,
+        selfDestructDelay: Duration?,
     ): SlackMessage
 
     fun searchGenericErrorMessage(): SlackMessage
@@ -89,6 +100,93 @@ internal class RealSlackMessageFactory(
         attachmentTitle: String,
         attachmentUrl: String,
         attachmentImageUrl: String,
+    ) = searchResultMessageWithActions(
+        searchQuery = searchQuery,
+        searchResults = searchResults,
+        attachmentTitle = attachmentTitle,
+        attachmentUrl = attachmentUrl,
+        attachmentImageUrl = attachmentImageUrl,
+        actions = listOf(
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SEND.apiValue,
+                text = SlackActionName.SEND.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+                style = ActionStylePrimary,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SELF_DESTRUCT_MENU.apiValue,
+                text = SlackActionName.SELF_DESTRUCT_MENU.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+                style = ActionStylePrimary,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SHUFFLE.apiValue,
+                text = SlackActionName.SHUFFLE.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.CANCEL.apiValue,
+                text = SlackActionName.CANCEL.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+            )
+        ),
+    )
+
+    override fun searchResultDelayMenuMessage(
+        searchQuery: String,
+        searchResults: Int,
+        searchSessionId: String,
+        attachmentTitle: String,
+        attachmentUrl: String,
+        attachmentImageUrl: String,
+    ) = searchResultMessageWithActions(
+        searchQuery = searchQuery,
+        searchResults = searchResults,
+        attachmentTitle = attachmentTitle,
+        attachmentUrl = attachmentUrl,
+        attachmentImageUrl = attachmentImageUrl,
+        actions = listOf(
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SELF_DESTRUCT_30_SEC.apiValue,
+                text = SlackActionName.SELF_DESTRUCT_30_SEC.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+                style = ActionStylePrimary,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SELF_DESTRUCT_1_MIN.apiValue,
+                text = SlackActionName.SELF_DESTRUCT_1_MIN.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+                style = ActionStylePrimary,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SELF_DESTRUCT_5_MIN.apiValue,
+                text = SlackActionName.SELF_DESTRUCT_5_MIN.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+                style = ActionStylePrimary,
+            ),
+            SlackMessage.Attachment.Action(
+                name = SlackActionName.SELF_DESTRUCT_MENU_BACK.apiValue,
+                text = SlackActionName.SELF_DESTRUCT_MENU_BACK.text,
+                type = ActionTypeButton,
+                value = searchSessionId,
+            )
+        ),
+    )
+
+    private fun searchResultMessageWithActions(
+        searchQuery: String,
+        searchResults: Int,
+        attachmentTitle: String,
+        attachmentUrl: String,
+        attachmentImageUrl: String,
+        actions: List<SlackMessage.Attachment.Action>,
     ) = message(
         text = "$searchQuery - ($searchResults result${if (searchResults == 1) "" else "s"} found)",
         attachments = listOf(
@@ -97,34 +195,7 @@ internal class RealSlackMessageFactory(
                 url = attachmentUrl,
                 imageUrl = attachmentImageUrl,
                 footer = PostedUsingFooter,
-                actions = listOf(
-                    SlackMessage.Attachment.Action(
-                        name = SlackActionName.SEND.apiValue,
-                        text = SlackActionName.SEND.text,
-                        type = ActionTypeButton,
-                        value = searchSessionId,
-                        style = ActionStylePrimary,
-                    ),
-                    SlackMessage.Attachment.Action(
-                        name = SlackActionName.SELF_DESTRUCT_5_MIN.apiValue,
-                        text = SlackActionName.SELF_DESTRUCT_5_MIN.text,
-                        type = ActionTypeButton,
-                        value = searchSessionId,
-                        style = ActionStylePrimary,
-                    ),
-                    SlackMessage.Attachment.Action(
-                        name = SlackActionName.SHUFFLE.apiValue,
-                        text = SlackActionName.SHUFFLE.text,
-                        type = ActionTypeButton,
-                        value = searchSessionId,
-                    ),
-                    SlackMessage.Attachment.Action(
-                        name = SlackActionName.CANCEL.apiValue,
-                        text = SlackActionName.CANCEL.text,
-                        type = ActionTypeButton,
-                        value = searchSessionId,
-                    )
-                ),
+                actions = actions,
             )
         ),
     )
@@ -167,7 +238,7 @@ internal class RealSlackMessageFactory(
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructMinutes: Int?,
+        selfDestructDelay: Duration?,
     ) = message(
         text = searchQuery,
         channelId = channelId,
@@ -179,7 +250,7 @@ internal class RealSlackMessageFactory(
                 url = attachmentUrl,
                 imageUrl = attachmentImageUrl,
                 actions = emptyList(),
-                footer = selfDestructMinutes?.let { "Self-destructing in ~$selfDestructMinutes minutes • $PostedUsingFooter" }
+                footer = selfDestructDelay?.let { "Self-destructing in ~${it.toFooterText()} • $PostedUsingFooter" }
                     ?: PostedUsingFooter,
             )
         ),
@@ -217,6 +288,12 @@ internal class RealSlackMessageFactory(
         private const val ActionStylePrimary = "primary"
 
         private const val PostedUsingFooter = "Posted using /codinglove"
+
+        private fun Duration.toFooterText() = if (this < 1.minutes) {
+            "$inWholeSeconds second${if (inWholeSeconds == 1L) "" else "s"}"
+        } else {
+            "$inWholeMinutes minute${if (inWholeMinutes == 1L) "" else "s"}"
+        }
 
         private fun randomSearchingMessage() = listOf(
             "\uD83D\uDD75\uFE0F\u200D♀\uFE0F Hang tight, we're finding your GIF...",

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/SlackMessageFactory.kt
@@ -6,8 +6,6 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackMessageResponseType
 import com.gchristov.thecodinglove.slack.domain.port.SlackAuthStateSerializer
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 
 interface SlackMessageFactory {
     fun message(
@@ -52,7 +50,7 @@ interface SlackMessageFactory {
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructDelay: Duration?,
+        selfDestructSeconds: Long?,
     ): SlackMessage
 
     fun searchGenericErrorMessage(): SlackMessage
@@ -238,7 +236,7 @@ internal class RealSlackMessageFactory(
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructDelay: Duration?,
+        selfDestructSeconds: Long?,
     ) = message(
         text = searchQuery,
         channelId = channelId,
@@ -250,7 +248,7 @@ internal class RealSlackMessageFactory(
                 url = attachmentUrl,
                 imageUrl = attachmentImageUrl,
                 actions = emptyList(),
-                footer = selfDestructDelay?.let { "Self-destructing in ~${it.toFooterText()} • $PostedUsingFooter" }
+                footer = selfDestructSeconds?.let { "Self-destructing in ~${it.toFooterText()} • $PostedUsingFooter" }
                     ?: PostedUsingFooter,
             )
         ),
@@ -289,10 +287,11 @@ internal class RealSlackMessageFactory(
 
         private const val PostedUsingFooter = "Posted using /codinglove"
 
-        private fun Duration.toFooterText() = if (this < 1.minutes) {
-            "$inWholeSeconds second${if (inWholeSeconds == 1L) "" else "s"}"
+        private fun Long.toFooterText() = if (this < 60) {
+            "$this second${if (this == 1L) "" else "s"}"
         } else {
-            "$inWholeMinutes minute${if (inWholeMinutes == 1L) "" else "s"}"
+            val minutes = this / 60
+            "$minutes minute${if (minutes == 1L) "" else "s"}"
         }
 
         private fun randomSearchingMessage() = listOf(

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackAuth.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackAuth.kt
@@ -1,10 +1,12 @@
 package com.gchristov.thecodinglove.slack.domain.model
 
+import kotlin.time.Duration
+
 data class SlackAuthState(
     val searchSessionId: String,
     val channelId: String,
     val teamId: String,
     val userId: String,
     val responseUrl: String,
-    val selfDestructMinutes: Int?,
+    val selfDestructDelay: Duration?,
 )

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackAuth.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackAuth.kt
@@ -1,12 +1,10 @@
 package com.gchristov.thecodinglove.slack.domain.model
 
-import kotlin.time.Duration
-
 data class SlackAuthState(
     val searchSessionId: String,
     val channelId: String,
     val teamId: String,
     val userId: String,
     val responseUrl: String,
-    val selfDestructDelay: Duration?,
+    val selfDestructSeconds: Long?,
 )

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackMessage.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/model/SlackMessage.kt
@@ -6,9 +6,11 @@ enum class SlackActionName(
 ) {
     AUTH_SEND(apiValue = "auth_send", text = "Allow"),
     SEND(apiValue = "send", text = "Send"),
-
-    // TODO: Consider adding more self-destruct times here if needed
-    SELF_DESTRUCT_5_MIN(apiValue = "self_destruct_5_min", text = "Send and erase in 5 minutes"),
+    SELF_DESTRUCT_MENU(apiValue = "self_destruct_menu", text = "Send and Erase After..."),
+    SELF_DESTRUCT_30_SEC(apiValue = "self_destruct_30_sec", text = "30 seconds"),
+    SELF_DESTRUCT_1_MIN(apiValue = "self_destruct_1_min", text = "1 minute"),
+    SELF_DESTRUCT_5_MIN(apiValue = "self_destruct_5_min", text = "5 minutes"),
+    SELF_DESTRUCT_MENU_BACK(apiValue = "self_destruct_menu_back", text = "Cancel"),
     SHUFFLE(apiValue = "shuffle", text = "Shuffle"),
     CANCEL(apiValue = "cancel", text = "Cancel"),
 }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
@@ -42,6 +42,6 @@ interface SlackSearchRepository {
         val attachmentTitle: String,
         val attachmentUrl: String,
         val attachmentImageUrl: String,
-        val searchResults: Int,
+        val totalPosts: Int,
     )
 }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/port/SlackSearchRepository.kt
@@ -42,5 +42,6 @@ interface SlackSearchRepository {
         val attachmentTitle: String,
         val attachmentUrl: String,
         val attachmentImageUrl: String,
+        val searchResults: Int,
     )
 }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
@@ -10,7 +10,6 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlin.time.Duration
 
 interface SlackEnsureAuthenticatedUseCase {
     suspend operator fun invoke(dto: Dto): Either<Throwable, Result>
@@ -26,7 +25,7 @@ interface SlackEnsureAuthenticatedUseCase {
         val channelId: String,
         val responseUrl: String,
         val searchSessionId: String,
-        val selfDestructDelay: Duration? = null,
+        val selfDestructSeconds: Long? = null,
     )
 }
 
@@ -48,7 +47,7 @@ internal class RealSlackEnsureAuthenticatedUseCase(
                 teamId = dto.teamId,
                 userId = dto.userId,
                 responseUrl = dto.responseUrl,
-                selfDestructDelay = dto.selfDestructDelay,
+                selfDestructSeconds = dto.selfDestructSeconds,
             )
             slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackEnsureAuthenticatedUseCase.kt
@@ -10,6 +10,7 @@ import com.gchristov.thecodinglove.slack.domain.model.SlackConfig
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
+import kotlin.time.Duration
 
 interface SlackEnsureAuthenticatedUseCase {
     suspend operator fun invoke(dto: Dto): Either<Throwable, Result>
@@ -25,7 +26,7 @@ interface SlackEnsureAuthenticatedUseCase {
         val channelId: String,
         val responseUrl: String,
         val searchSessionId: String,
-        val selfDestructMinutes: Int? = null,
+        val selfDestructDelay: Duration? = null,
     )
 }
 
@@ -47,7 +48,7 @@ internal class RealSlackEnsureAuthenticatedUseCase(
                 teamId = dto.teamId,
                 userId = dto.userId,
                 responseUrl = dto.responseUrl,
-                selfDestructMinutes = dto.selfDestructMinutes,
+                selfDestructDelay = dto.selfDestructDelay,
             )
             slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
@@ -11,7 +11,7 @@ import com.gchristov.thecodinglove.slack.domain.model.isSelfDestruct
 import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
 import kotlin.time.Clock
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -29,7 +29,7 @@ interface SlackSendSearchUseCase {
         val channelId: String,
         val responseUrl: String,
         val searchSessionId: String,
-        val selfDestructDelay: Duration? = null,
+        val selfDestructSeconds: Long? = null,
     )
 }
 
@@ -53,7 +53,7 @@ internal class RealSlackSendSearchUseCase(
                 teamId = dto.teamId,
                 userId = dto.userId,
                 responseUrl = dto.responseUrl,
-                selfDestructDelay = dto.selfDestructDelay,
+                selfDestructSeconds = dto.selfDestructSeconds,
             )
             val token = slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }
@@ -83,11 +83,11 @@ internal class RealSlackSendSearchUseCase(
                 attachmentUrl = searchSessionPost.attachmentUrl,
                 attachmentImageUrl = searchSessionPost.attachmentImageUrl,
                 channelId = authState.channelId,
-                selfDestructDelay = authState.selfDestructDelay,
+                selfDestructSeconds = authState.selfDestructSeconds,
             ),
         ).getOrElse { return Either.Left(it) }
-        val logPlaceholder = authState.selfDestructDelay?.let { "self-destruct" } ?: "sent"
-        val state = authState.selfDestructDelay?.let {
+        val logPlaceholder = authState.selfDestructSeconds?.let { "self-destruct" } ?: "sent"
+        val state = authState.selfDestructSeconds?.let {
             SlackSearchRepository.SearchSessionStateDto.SelfDestruct
         } ?: SlackSearchRepository.SearchSessionStateDto.Sent
         log.debug(tag, "Marking search session as $logPlaceholder: searchSessionId=${authState.searchSessionId}")
@@ -95,8 +95,8 @@ internal class RealSlackSendSearchUseCase(
             searchSessionId = authState.searchSessionId,
             state = state,
         ).getOrElse { return Either.Left(it) }
-        val destroyTimestamp = authState.selfDestructDelay?.let { delay ->
-            (clock.now() + delay).toEpochMilliseconds()
+        val destroyTimestamp = authState.selfDestructSeconds?.let { seconds ->
+            (clock.now() + seconds.seconds).toEpochMilliseconds()
         }
         val message = SlackSentMessage(
             id = authState.searchSessionId,

--- a/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
+++ b/slack/domain/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/SlackSendSearchUseCase.kt
@@ -11,11 +11,10 @@ import com.gchristov.thecodinglove.slack.domain.model.isSelfDestruct
 import com.gchristov.thecodinglove.slack.domain.port.SlackSearchRepository
 import com.gchristov.thecodinglove.slack.domain.port.SlackRepository
 import kotlin.time.Clock
+import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.DateTimeUnit
-import kotlinx.datetime.plus
 
 interface SlackSendSearchUseCase {
     suspend operator fun invoke(dto: Dto): Either<Throwable, SlackSentMessage>
@@ -30,7 +29,7 @@ interface SlackSendSearchUseCase {
         val channelId: String,
         val responseUrl: String,
         val searchSessionId: String,
-        val selfDestructMinutes: Int? = null,
+        val selfDestructDelay: Duration? = null,
     )
 }
 
@@ -54,7 +53,7 @@ internal class RealSlackSendSearchUseCase(
                 teamId = dto.teamId,
                 userId = dto.userId,
                 responseUrl = dto.responseUrl,
-                selfDestructMinutes = dto.selfDestructMinutes,
+                selfDestructDelay = dto.selfDestructDelay,
             )
             val token = slackRepository.getAuthToken(tokenId = dto.userId).getOrElse { error ->
                 log.debug(tag, error) { "Error fetching user token${error.message?.let { ": $it" } ?: ""}" }
@@ -84,11 +83,11 @@ internal class RealSlackSendSearchUseCase(
                 attachmentUrl = searchSessionPost.attachmentUrl,
                 attachmentImageUrl = searchSessionPost.attachmentImageUrl,
                 channelId = authState.channelId,
-                selfDestructMinutes = authState.selfDestructMinutes,
+                selfDestructDelay = authState.selfDestructDelay,
             ),
         ).getOrElse { return Either.Left(it) }
-        val logPlaceholder = authState.selfDestructMinutes?.let { "self-destruct" } ?: "sent"
-        val state = authState.selfDestructMinutes?.let {
+        val logPlaceholder = authState.selfDestructDelay?.let { "self-destruct" } ?: "sent"
+        val state = authState.selfDestructDelay?.let {
             SlackSearchRepository.SearchSessionStateDto.SelfDestruct
         } ?: SlackSearchRepository.SearchSessionStateDto.Sent
         log.debug(tag, "Marking search session as $logPlaceholder: searchSessionId=${authState.searchSessionId}")
@@ -96,8 +95,8 @@ internal class RealSlackSendSearchUseCase(
             searchSessionId = authState.searchSessionId,
             state = state,
         ).getOrElse { return Either.Left(it) }
-        val destroyTimestamp = authState.selfDestructMinutes?.let { minutes ->
-            clock.now().plus(value = minutes, unit = DateTimeUnit.MINUTE).toEpochMilliseconds()
+        val destroyTimestamp = authState.selfDestructDelay?.let { delay ->
+            (clock.now() + delay).toEpochMilliseconds()
         }
         val message = SlackSentMessage(
             id = authState.searchSessionId,

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/RealSlackMessageFactoryTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/RealSlackMessageFactoryTest.kt
@@ -8,8 +8,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.minutes
-import kotlin.time.Duration.Companion.seconds
 
 class RealSlackMessageFactoryTest {
     private val factory = RealSlackMessageFactory(FakeSlackAuthStateSerializer())
@@ -129,14 +127,14 @@ class RealSlackMessageFactoryTest {
     }
 
     @Test
-    fun searchPostMessageWithMinuteSelfDestructDelayIncludesMinutesInFooter() {
+    fun searchPostMessageWithMinuteSelfDestructSecondsIncludesMinutesInFooter() {
         val message = factory.searchPostMessage(
             searchQuery = "test",
             attachmentTitle = "title",
             attachmentUrl = "url",
             attachmentImageUrl = "imageUrl",
             channelId = "channel_1",
-            selfDestructDelay = 5.minutes,
+            selfDestructSeconds = 300L,
         )
         val footer = message.attachments?.firstOrNull()?.footer
         assertNotNull(footer)
@@ -144,14 +142,14 @@ class RealSlackMessageFactoryTest {
     }
 
     @Test
-    fun searchPostMessageWithSecondSelfDestructDelayIncludesSecondsInFooter() {
+    fun searchPostMessageWithSecondSelfDestructSecondsIncludesSecondsInFooter() {
         val message = factory.searchPostMessage(
             searchQuery = "test",
             attachmentTitle = "title",
             attachmentUrl = "url",
             attachmentImageUrl = "imageUrl",
             channelId = "channel_1",
-            selfDestructDelay = 30.seconds,
+            selfDestructSeconds = 30L,
         )
         val footer = message.attachments?.firstOrNull()?.footer
         assertNotNull(footer)
@@ -159,14 +157,14 @@ class RealSlackMessageFactoryTest {
     }
 
     @Test
-    fun searchPostMessageWithoutSelfDestructDelayUsesDefaultFooter() {
+    fun searchPostMessageWithoutSelfDestructSecondsUsesDefaultFooter() {
         val message = factory.searchPostMessage(
             searchQuery = "test",
             attachmentTitle = "title",
             attachmentUrl = "url",
             attachmentImageUrl = "imageUrl",
             channelId = "channel_1",
-            selfDestructDelay = null,
+            selfDestructSeconds = null,
         )
         val footer = message.attachments?.firstOrNull()?.footer
         assertEquals(expected = "Posted using /codinglove", actual = footer)
@@ -180,7 +178,7 @@ class RealSlackMessageFactoryTest {
             teamId = "team_1",
             userId = "user_1",
             responseUrl = "https://response.url",
-            selfDestructDelay = null,
+            selfDestructSeconds = null,
         )
         val message = factory.authMessage(clientId = "client_1", authState = authState)
         val authUrl = message.attachments?.firstOrNull()?.actions?.firstOrNull()?.url

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/RealSlackMessageFactoryTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/RealSlackMessageFactoryTest.kt
@@ -1,11 +1,15 @@
 package com.gchristov.thecodinglove.slack.domain
 
+import com.gchristov.thecodinglove.common.slack.model.SlackMessage
+import com.gchristov.thecodinglove.slack.domain.model.SlackActionName
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import com.gchristov.thecodinglove.slack.testfixtures.FakeSlackAuthStateSerializer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class RealSlackMessageFactoryTest {
     private val factory = RealSlackMessageFactory(FakeSlackAuthStateSerializer())
@@ -37,14 +41,102 @@ class RealSlackMessageFactoryTest {
     }
 
     @Test
-    fun searchPostMessageWithSelfDestructMinutesIncludesSelfDestructInFooter() {
+    fun searchResultMessageHasSendMenuShuffleAndCancelActions() {
+        val message = factory.searchResultMessage(
+            searchQuery = "test",
+            searchResults = 5,
+            searchSessionId = "session_1",
+            attachmentTitle = "title",
+            attachmentUrl = "url",
+            attachmentImageUrl = "imageUrl",
+        )
+        assertEquals(
+            expected = listOf(
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SEND.apiValue,
+                    text = SlackActionName.SEND.text,
+                    type = "button",
+                    value = "session_1",
+                    style = "primary",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SELF_DESTRUCT_MENU.apiValue,
+                    text = SlackActionName.SELF_DESTRUCT_MENU.text,
+                    type = "button",
+                    value = "session_1",
+                    style = "primary",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SHUFFLE.apiValue,
+                    text = SlackActionName.SHUFFLE.text,
+                    type = "button",
+                    value = "session_1",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.CANCEL.apiValue,
+                    text = SlackActionName.CANCEL.text,
+                    type = "button",
+                    value = "session_1",
+                ),
+            ),
+            actual = message.attachments?.firstOrNull()?.actions,
+        )
+    }
+
+    @Test
+    fun searchResultDelayMenuMessageHasDelayChoicesAndBackActions() {
+        val message = factory.searchResultDelayMenuMessage(
+            searchQuery = "test",
+            searchResults = 5,
+            searchSessionId = "session_1",
+            attachmentTitle = "title",
+            attachmentUrl = "url",
+            attachmentImageUrl = "imageUrl",
+        )
+        assertEquals(expected = "test - (5 results found)", actual = message.text)
+        assertEquals(
+            expected = listOf(
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SELF_DESTRUCT_30_SEC.apiValue,
+                    text = SlackActionName.SELF_DESTRUCT_30_SEC.text,
+                    type = "button",
+                    value = "session_1",
+                    style = "primary",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SELF_DESTRUCT_1_MIN.apiValue,
+                    text = SlackActionName.SELF_DESTRUCT_1_MIN.text,
+                    type = "button",
+                    value = "session_1",
+                    style = "primary",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SELF_DESTRUCT_5_MIN.apiValue,
+                    text = SlackActionName.SELF_DESTRUCT_5_MIN.text,
+                    type = "button",
+                    value = "session_1",
+                    style = "primary",
+                ),
+                SlackMessage.Attachment.Action(
+                    name = SlackActionName.SELF_DESTRUCT_MENU_BACK.apiValue,
+                    text = SlackActionName.SELF_DESTRUCT_MENU_BACK.text,
+                    type = "button",
+                    value = "session_1",
+                ),
+            ),
+            actual = message.attachments?.firstOrNull()?.actions,
+        )
+    }
+
+    @Test
+    fun searchPostMessageWithMinuteSelfDestructDelayIncludesMinutesInFooter() {
         val message = factory.searchPostMessage(
             searchQuery = "test",
             attachmentTitle = "title",
             attachmentUrl = "url",
             attachmentImageUrl = "imageUrl",
             channelId = "channel_1",
-            selfDestructMinutes = 5,
+            selfDestructDelay = 5.minutes,
         )
         val footer = message.attachments?.firstOrNull()?.footer
         assertNotNull(footer)
@@ -52,14 +144,29 @@ class RealSlackMessageFactoryTest {
     }
 
     @Test
-    fun searchPostMessageWithoutSelfDestructMinutesUsesDefaultFooter() {
+    fun searchPostMessageWithSecondSelfDestructDelayIncludesSecondsInFooter() {
         val message = factory.searchPostMessage(
             searchQuery = "test",
             attachmentTitle = "title",
             attachmentUrl = "url",
             attachmentImageUrl = "imageUrl",
             channelId = "channel_1",
-            selfDestructMinutes = null,
+            selfDestructDelay = 30.seconds,
+        )
+        val footer = message.attachments?.firstOrNull()?.footer
+        assertNotNull(footer)
+        assertTrue { footer.contains("Self-destructing in ~30 seconds") }
+    }
+
+    @Test
+    fun searchPostMessageWithoutSelfDestructDelayUsesDefaultFooter() {
+        val message = factory.searchPostMessage(
+            searchQuery = "test",
+            attachmentTitle = "title",
+            attachmentUrl = "url",
+            attachmentImageUrl = "imageUrl",
+            channelId = "channel_1",
+            selfDestructDelay = null,
         )
         val footer = message.attachments?.firstOrNull()?.footer
         assertEquals(expected = "Posted using /codinglove", actual = footer)
@@ -73,7 +180,7 @@ class RealSlackMessageFactoryTest {
             teamId = "team_1",
             userId = "user_1",
             responseUrl = "https://response.url",
-            selfDestructMinutes = null,
+            selfDestructDelay = null,
         )
         val message = factory.authMessage(clientId = "client_1", authState = authState)
         val authUrl = message.attachments?.firstOrNull()?.actions?.firstOrNull()?.url

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
@@ -73,5 +73,5 @@ private val TestDto = SlackEnsureAuthenticatedUseCase.Dto(
     channelId = "channel_id",
     responseUrl = "https://response.url",
     searchSessionId = "session_123",
-    selfDestructDelay = null,
+    selfDestructSeconds = null,
 )

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackEnsureAuthenticatedUseCaseTest.kt
@@ -73,5 +73,5 @@ private val TestDto = SlackEnsureAuthenticatedUseCase.Dto(
     channelId = "channel_id",
     responseUrl = "https://response.url",
     searchSessionId = "session_123",
-    selfDestructMinutes = null,
+    selfDestructDelay = null,
 )

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalTime::class)
 class RealSlackSendSearchUseCaseTest {
@@ -92,7 +93,7 @@ class RealSlackSendSearchUseCaseTest {
     fun sendSuccessWithSelfDestructSavesSelfDestructStateAndReturnsIt(): TestResult = runBlockingTest(
         getAuthTokenResult = Either.Right(SlackAuthTokenCreator.token()),
     ) { useCase, repository, _ ->
-        val actual = useCase.invoke(TestDto.copy(selfDestructMinutes = 5))
+        val actual = useCase.invoke(TestDto.copy(selfDestructDelay = 5.minutes))
         assertTrue { actual.isRight() }
         val message = actual.getOrElse { null }
         assertNotNull(message)
@@ -138,7 +139,7 @@ private val TestDto = SlackSendSearchUseCase.Dto(
     channelId = "channel_id",
     responseUrl = "https://response.url",
     searchSessionId = "session_123",
-    selfDestructMinutes = null,
+    selfDestructDelay = null,
 )
 @OptIn(ExperimentalTime::class)
 private val TestClock = object : Clock {

--- a/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
+++ b/slack/domain/src/commonTest/kotlin/com/gchristov/thecodinglove/slack/domain/usecase/RealSlackSendSearchUseCaseTest.kt
@@ -22,7 +22,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.minutes
 
 @OptIn(ExperimentalTime::class)
 class RealSlackSendSearchUseCaseTest {
@@ -93,7 +92,7 @@ class RealSlackSendSearchUseCaseTest {
     fun sendSuccessWithSelfDestructSavesSelfDestructStateAndReturnsIt(): TestResult = runBlockingTest(
         getAuthTokenResult = Either.Right(SlackAuthTokenCreator.token()),
     ) { useCase, repository, _ ->
-        val actual = useCase.invoke(TestDto.copy(selfDestructDelay = 5.minutes))
+        val actual = useCase.invoke(TestDto.copy(selfDestructSeconds = 300L))
         assertTrue { actual.isRight() }
         val message = actual.getOrElse { null }
         assertNotNull(message)
@@ -139,7 +138,7 @@ private val TestDto = SlackSendSearchUseCase.Dto(
     channelId = "channel_id",
     responseUrl = "https://response.url",
     searchSessionId = "session_123",
-    selfDestructDelay = null,
+    selfDestructSeconds = null,
 )
 @OptIn(ExperimentalTime::class)
 private val TestClock = object : Clock {

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackMessageFactory.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackMessageFactory.kt
@@ -4,6 +4,7 @@ import com.gchristov.thecodinglove.common.slack.model.SlackMessage
 import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackMessageResponseType
+import kotlin.time.Duration
 
 class FakeSlackMessageFactory : SlackMessageFactory {
     override fun message(
@@ -27,6 +28,15 @@ class FakeSlackMessageFactory : SlackMessageFactory {
         attachmentImageUrl: String,
     ) = dummyMessage()
 
+    override fun searchResultDelayMenuMessage(
+        searchQuery: String,
+        searchResults: Int,
+        searchSessionId: String,
+        attachmentTitle: String,
+        attachmentUrl: String,
+        attachmentImageUrl: String,
+    ) = dummyMessage()
+
     override fun authMessage(clientId: String, authState: SlackAuthState) = dummyMessage()
 
     override fun searchPostMessage(
@@ -35,7 +45,7 @@ class FakeSlackMessageFactory : SlackMessageFactory {
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructMinutes: Int?,
+        selfDestructDelay: Duration?,
     ) = dummyMessage()
 
     override fun searchGenericErrorMessage() = dummyMessage()

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackMessageFactory.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackMessageFactory.kt
@@ -4,7 +4,6 @@ import com.gchristov.thecodinglove.common.slack.model.SlackMessage
 import com.gchristov.thecodinglove.slack.domain.SlackMessageFactory
 import com.gchristov.thecodinglove.slack.domain.model.SlackAuthState
 import com.gchristov.thecodinglove.slack.domain.model.SlackMessageResponseType
-import kotlin.time.Duration
 
 class FakeSlackMessageFactory : SlackMessageFactory {
     override fun message(
@@ -45,7 +44,7 @@ class FakeSlackMessageFactory : SlackMessageFactory {
         attachmentUrl: String,
         attachmentImageUrl: String,
         channelId: String,
-        selfDestructDelay: Duration?,
+        selfDestructSeconds: Long?,
     ) = dummyMessage()
 
     override fun searchGenericErrorMessage() = dummyMessage()

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackSendSearchUseCase.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackSendSearchUseCase.kt
@@ -4,20 +4,21 @@ import arrow.core.Either
 import com.gchristov.thecodinglove.slack.domain.model.SlackSentMessage
 import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlin.test.assertEquals
+import kotlin.time.Duration
 
 class FakeSlackSendSearchUseCase(
     private val invocationResult: Either<Throwable, SlackSentMessage> = Either.Right(SlackSentMessageCreator.message()),
 ) : SlackSendSearchUseCase {
     private var invocations = 0
-    private var lastSelfDestructMinutes: Int? = null
+    private var lastSelfDestructDelay: Duration? = null
 
     override suspend fun invoke(dto: SlackSendSearchUseCase.Dto): Either<Throwable, SlackSentMessage> {
-        lastSelfDestructMinutes = dto.selfDestructMinutes
+        lastSelfDestructDelay = dto.selfDestructDelay
         invocations++
         return invocationResult
     }
 
     fun assertInvokedOnce() = assertEquals(expected = 1, actual = invocations)
     fun assertNotInvoked() = assertEquals(expected = 0, actual = invocations)
-    fun assertSelfDestructMinutes(minutes: Int?) = assertEquals(expected = minutes, actual = lastSelfDestructMinutes)
+    fun assertSelfDestructDelay(delay: Duration?) = assertEquals(expected = delay, actual = lastSelfDestructDelay)
 }

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackSendSearchUseCase.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/FakeSlackSendSearchUseCase.kt
@@ -4,21 +4,20 @@ import arrow.core.Either
 import com.gchristov.thecodinglove.slack.domain.model.SlackSentMessage
 import com.gchristov.thecodinglove.slack.domain.usecase.SlackSendSearchUseCase
 import kotlin.test.assertEquals
-import kotlin.time.Duration
 
 class FakeSlackSendSearchUseCase(
     private val invocationResult: Either<Throwable, SlackSentMessage> = Either.Right(SlackSentMessageCreator.message()),
 ) : SlackSendSearchUseCase {
     private var invocations = 0
-    private var lastSelfDestructDelay: Duration? = null
+    private var lastSelfDestructSeconds: Long? = null
 
     override suspend fun invoke(dto: SlackSendSearchUseCase.Dto): Either<Throwable, SlackSentMessage> {
-        lastSelfDestructDelay = dto.selfDestructDelay
+        lastSelfDestructSeconds = dto.selfDestructSeconds
         invocations++
         return invocationResult
     }
 
     fun assertInvokedOnce() = assertEquals(expected = 1, actual = invocations)
     fun assertNotInvoked() = assertEquals(expected = 0, actual = invocations)
-    fun assertSelfDestructDelay(delay: Duration?) = assertEquals(expected = delay, actual = lastSelfDestructDelay)
+    fun assertSelfDestructSeconds(seconds: Long?) = assertEquals(expected = seconds, actual = lastSelfDestructSeconds)
 }

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/SlackSearchResultCreator.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/SlackSearchResultCreator.kt
@@ -27,11 +27,11 @@ object SlackSearchResultCreator {
 }
 
 object SlackSearchSessionPostCreator {
-    fun post(searchResults: Int = 10) = SlackSearchRepository.SearchSessionPostDto(
+    fun post(totalPosts: Int = 10) = SlackSearchRepository.SearchSessionPostDto(
         searchQuery = "test",
         attachmentTitle = "title",
         attachmentUrl = "url",
         attachmentImageUrl = "imageUrl",
-        searchResults = searchResults,
+        totalPosts = totalPosts,
     )
 }

--- a/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/SlackSearchResultCreator.kt
+++ b/slack/test-fixtures/src/commonMain/kotlin/com/gchristov/thecodinglove/slack/testfixtures/SlackSearchResultCreator.kt
@@ -27,10 +27,11 @@ object SlackSearchResultCreator {
 }
 
 object SlackSearchSessionPostCreator {
-    fun post() = SlackSearchRepository.SearchSessionPostDto(
+    fun post(searchResults: Int = 10) = SlackSearchRepository.SearchSessionPostDto(
         searchQuery = "test",
         attachmentTitle = "title",
         attachmentUrl = "url",
         attachmentImageUrl = "imageUrl",
+        searchResults = searchResults,
     )
 }


### PR DESCRIPTION
## What does this pull request change?

Until now, asking the app to send a GIF and have it disappear again only offered one fixed option: five minutes. This replaces that single button with a small menu — press "Send and Erase After...", and you're shown three delay choices (30 seconds, 1 minute, or 5 minutes) along with a way to back out to the original choices if you change your mind. Picking a delay sends the GIF exactly as before, just with the timing you chose. Everything else about sending, shuffling, or cancelling a search result works the same as it does today.

## How is this change tested?

Unit tests cover the new menu-revealing and "back" interactions, the three delay choices (including a 30-second one, to confirm sub-minute delays work correctly), and the message text/buttons shown at each step. `./gradlew build` passes for both the `search` and `slack` microservices (compiles, DI graph resolves, all unit tests pass).

---

[Writing Kotlin Multiplatform tests](https://kotlinlang.org/docs/js-running-tests.html)